### PR TITLE
Prlp demo adjust reset method

### DIFF
--- a/reinforcement-learning-games/prlp-demo/CHANGELOG.md
+++ b/reinforcement-learning-games/prlp-demo/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.0 
+
+Adjusting the reset method in the gym implementation to return both an initial observation and an info dictionary.
+This is to align with the gym specification.
+
 # 1.1.0 
 
 Adding a gym wrapper for the demo environment.

--- a/reinforcement-learning-games/prlp-demo/prlp_demo/__init__.py
+++ b/reinforcement-learning-games/prlp-demo/prlp_demo/__init__.py
@@ -8,5 +8,5 @@ Created on Nov 10, 2016
 #            Starting at 1.0 as this code was obtained from a separate project.
 #            This version 1.0 might include changes made for the projects in this repo.
 #            Version changes will be made for any further changes.
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 

--- a/reinforcement-learning-games/prlp-demo/prlp_demo/gym_env.py
+++ b/reinforcement-learning-games/prlp-demo/prlp_demo/gym_env.py
@@ -107,7 +107,7 @@ class DemoGymEnv(object):
             observation (object): the initial observation.
         """
         self.game.reset()
-        return self.get_observation()
+        return self.get_observation(), {}
 
     def render(self, mode='human'):
         """Renders the environment.

--- a/reinforcement-learning-games/prlp-demo/tests/test_gym_env.py
+++ b/reinforcement-learning-games/prlp-demo/tests/test_gym_env.py
@@ -11,7 +11,7 @@ def test_gym_env_frame_size():
     env = DemoGymEnv(
         enable_rendering=False
     )
-    observation = env.reset()
+    observation, _ = env.reset()
     feedback_size = env.get_frame_size()
     expected_observation_shape = (1,) + feedback_size
     assert observation.shape == expected_observation_shape
@@ -20,7 +20,7 @@ def test_gym_env_step():
     env = DemoGymEnv(
         enable_rendering=False
     )
-    observation = env.reset()
+    observation, _ = env.reset()
     step_count = 0
     done = False
     while (not done) and (step_count < 100):


### PR DESCRIPTION
Adjusting the reset method in the gym implementation of the PRLP demo environment to return both an initial observation and an info dictionary.  This is to align with the gym specification.