### PR TITLE
DQN flake and package updates

### DIFF
--- a/reinforcement-learning-games/zombsole-gym-example/eval_dqn.py
+++ b/reinforcement-learning-games/zombsole-gym-example/eval_dqn.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 '''
 Created on Mar 28, 2018
 

--- a/reinforcement-learning-games/zombsole-gym-example/flake.lock
+++ b/reinforcement-learning-games/zombsole-gym-example/flake.lock
@@ -29,11 +29,11 @@
       },
       "locked": {
         "dir": "reinforcement-learning-games/prlp-demo",
-        "lastModified": 1736346340,
-        "narHash": "sha256-T94fEJ/0fcdlLbMACGsrxAzDV65SNw5Rk6Ctq12nO+8=",
+        "lastModified": 1740577344,
+        "narHash": "sha256-hv7y1ZYIkFQudhGZkf0ukkYL/fjo4OX+porv2oPf/Cw=",
         "owner": "jvstinian",
         "repo": "data-science-projects",
-        "rev": "d2f390dcb2787d7f0bc3ef23331c46930c8246e3",
+        "rev": "4fdda467aaf81770811eb2b30e7cae89754ec1fe",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736466503,
-        "narHash": "sha256-GuF9/b/q/UMuqm9Q1tpvNZalmKu0yuCm22EVXGojUT0=",
+        "lastModified": 1740404743,
+        "narHash": "sha256-YIYbJgCy0S9VG1JsRU5VOGAM6ycYC3+fc1bV3YC1Drc=",
         "owner": "jvstinian",
         "repo": "zombpyg",
-        "rev": "92e01a97baaaadac03ee29279d5336d07fa4d5a7",
+        "rev": "b98c7282d449c2e2644ba1a6c4e50df08219df09",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736115236,
-        "narHash": "sha256-E4Dyygqjv51aE9nAL/dl6b5G6hzUTmmSp8J8IgY8wdA=",
+        "lastModified": 1740491422,
+        "narHash": "sha256-A270LqAq3xbQFl+lIWSAFKZpat7RupCNocqarnzrEag=",
         "owner": "jvstinian",
         "repo": "libzombsole",
-        "rev": "cd80e16ac09a51ab134128b688f8386b8358e8dc",
+        "rev": "7646232830bc57bcf32d232463e2e5827342dcb4",
         "type": "github"
       },
       "original": {

--- a/reinforcement-learning-games/zombsole-gym-example/flake.nix
+++ b/reinforcement-learning-games/zombsole-gym-example/flake.nix
@@ -42,26 +42,9 @@
           ];
           dev-python = pkgs.python3.withPackages dev-python-packages;
 
-          # This is probably not the way I'll go
-          train-script = pkgs.writeShellScriptBin "train.sh" ''
-            python train_dqn.py --config zombsole_cnn
-          '';
-
-          my-process-bundle = pkgs.symlinkJoin {
-              name = "my-process-bundle";
-              buildInputs = [ pkgs.makeWrapper ];
-              postBuild = ''
-                  echo "NOTE: Links added in symlinkJoin"
-                  makeWrapper ${train-script}/bin/train.sh $out/bin/my-wrapper --prefix PATH : $out/bin
-              '';
-              paths = [
-                dev-python
-              ];
-          };
-          
           # Will likely go this way instead
           python-train-app = pkgs.python3Packages.buildPythonApplication {
-            pname = "dqn-train-example";
+            pname = "dqn-train-examples";
             version = "1.0";
             propagatedBuildInputs = dev-python-packages pkgs.python3Packages;
             src = ./.;
@@ -74,16 +57,18 @@
           shellHook = "export PS1='\\[\\e[1;34m\\]dqn-train-dev > \\[\\e[0m\\]'";
         };
         packages = {
-          pytrain = python-train-app;
+          dqn-train = python-train-app;
         };
-        apps.wrappertrain = {
-          type = "app";
-          program = "${my-process-bundle}/bin/my-wrapper";
-        };
-        apps.pytrain = {
-          type = "app";
-          program = "${python-train-app}/bin/train_dqn.py";
-        };
+        apps = {
+	  dqn-train = {
+	    type = "app";
+            program = "${python-train-app}/bin/train_dqn.py";
+          };
+	  dqn-eval = {
+	    type = "app";
+            program = "${python-train-app}/bin/eval_dqn.py";
+          };
+	};
       }
     );
 }

--- a/reinforcement-learning-games/zombsole-gym-example/setup.py
+++ b/reinforcement-learning-games/zombsole-gym-example/setup.py
@@ -9,5 +9,5 @@ setup(
         # packages=find_packages(include=["dqn"]),
         packages=find_packages(),
         # Executables
-        scripts=["train_dqn.py"],
+        scripts=["train_dqn.py", "eval_dqn.py"],
 )


### PR DESCRIPTION
Updating `dqn-train-examples` app to include the eval script in the package.  

Updating the flake.  An eval app has been added.  The old wrapper approach has been removed.

Resolves #21 