### PR TITLE
Monte Carlo evaluation examples

### DIFF
--- a/experiments/ada/blackjack/mc_policy_evaluation_example.adb
+++ b/experiments/ada/blackjack/mc_policy_evaluation_example.adb
@@ -1,0 +1,658 @@
+with Ada.Text_IO; use Ada.Text_IO;
+with Ada.Integer_Text_IO; use Ada.Integer_Text_IO;
+with Ada.Float_Text_IO; use Ada.Float_Text_IO;
+with Blackjack; use Blackjack;
+with Ada.Containers; use Ada.Containers;
+with Ada.Containers.Bounded_Hashed_Maps;
+with Ada.Numerics.Discrete_Random;
+with Ada.Numerics.Float_Random;
+
+ 
+procedure MC_Policy_Evaluation_Example is
+   -- We use the "Auto_Hit" option which automatically hits till the player
+   -- has a sum of 12 or more, so we only need to consider player sums of 12-21,
+   -- or ten possible values.
+   -- We also consider whether the player has a usable ace or not, which represents
+   -- two possible values.
+   -- The dealer cards can have a value of 1-10.
+   -- So overall there are 200 = 2 * 10 * 10 possible non-terminal states.
+   -- We also add a terminal state which is used when the player sum exceeds 21.
+   Num_Discrete_States : constant Integer := 2 * 10 * 10 + 1;
+   type Discrete_Observation_Type is range 0 .. Num_Discrete_States - 1;
+   -- subtype Discrete_Observation_Type2 is Discrete_Observation_Type range 0 .. 30;
+   function To_Discrete_Observation(Obs : Observation_Type) return Discrete_Observation_Type is
+      Dealer_Value_Index : Natural := Obs.Dealer_Showing_Card_Value - 1;
+      Player_Value_Index : Natural;
+      Res : Discrete_Observation_Type;
+   begin
+      if Obs.Player_Sum > 21 then
+         return Discrete_Observation_Type'Last; -- Terminal state for player going bust
+      end if;
+         Player_Value_Index := Boolean'Pos(Obs.Usable_Ace) * 10 + (Obs.Player_Sum - 12); -- 10 for the range 12 .. 21
+      -- if Obs.Usable_Ace then
+      --    Obs.Player_Sum - 12; -- Player sums with a usable ace can be 12-21
+      --    Player_Value_Index := Player_Value_Index + 20; -- Usable ace states come after non-usable ace states
+      -- else 
+      --    Player_Value_Index := Obs.Player_Sum - 2; -- Player sums without a usable ace can be 2-21
+      -- end if;
+      return Discrete_Observation_Type(Player_Value_Index * 10 + Dealer_Value_Index);
+   end;
+
+   -- Env : Environment_Type := Make(Config_Type'(Natural_Win_Reward => SAB, Auto_Hit => True));
+
+   -- Hash Map approach
+   -- function Observation_Hash (Obs : Observation_Type) return Hash_Type is
+   --    Card_Value : Integer := Card_Type'Pos(Obs.Dealer_Showing_Card);
+   --    Ace_Offset : Integer := Boolean'Pos(Obs.Usable_Ace);
+   -- begin
+   --    return Hash_Type(Obs.Player_Sum) xor Hash_Type(Card_Value) xor Hash_Type(Ace_Offset);
+   -- end Observation_Hash;
+   -- 
+   -- package State_Value_Map_Type is new Ada.Containers.Bounded_Hashed_Maps (
+   --       Key_Type => Observation_Type,
+   --       Element_Type => Float, -- TODO
+   --       Hash => Observation_Hash,
+   --       Equivalent_Keys => "=");
+
+   -- State_Value_Map : State_Value_Map_Type.Map(20, Hash_Type(16)); --  := State_Value_Map_Type.Empty_Map;
+
+   type MC_Visit_Type is (First_Visit, Every_Visit);
+   type MC_Config_Type is record
+      Num_Episodes : Integer;
+      Visit_Type : MC_Visit_Type;
+      Discount_Factor : Float := 1.0;
+   end record;
+
+   type Policy_Type is array (Discrete_Observation_Type) of Action_Type;
+   type Value_Function_Type is array(Discrete_Observation_Type) of Float;
+
+   type Mixed_Policy_Type is array (Discrete_Observation_Type, Action_Type) of Float;
+
+   function MC_Policy_Evaluation(Policy : Policy_Type; MC_Config : MC_Config_Type) return Value_Function_Type is
+      type Reward_Tracker_Type is record
+         Total_Reward : Float;
+         Count : Integer;
+      end record;
+
+      type State_Reward_Tracker_Type is array(Discrete_Observation_Type) of Reward_Tracker_Type;
+
+      type SAR_Type is record
+         State : Discrete_Observation_Type;
+         Action : Action_Type;
+         Reward : Float;
+      end record;
+
+      type SAR_Array_Type is array (1 .. 21) of SAR_Type;
+      SAR_Array : SAR_Array_Type;
+
+      V : State_Reward_Tracker_Type := (others => (0.0, 0));
+      -- Returns_Sum : array(Observation_Type) of Float := (others => 0.0);
+      -- Returns_Count : array(Observation_Type) of Integer := (others => 0);
+      -- Obs : Observation_Type;
+      Env : Environment_Type := Make(Config_Type'(Natural_Win_Reward => SAB, Auto_Hit => True));
+      Obs : Observation_Type;
+      Step_Output : Step_Return_Type;
+      Discrete_Obs : Discrete_Observation_Type;
+      Action : Action_Type;
+      Terminated : Boolean;
+      -- I : Natural;
+      Last_I : Natural;
+      Cumulative_Reward : Float;  -- TODO: Is this needed?
+
+      procedure Every_Visit_Reward_Update(V : in out State_Reward_Tracker_Type; SAR_Array_Input: SAR_Array_Type; Last_I : Natural) is
+         SAR_Array : SAR_Array_Type := SAR_Array_Input; -- A local copy to avoid specifying "in out" for the array parameter
+      begin
+         for I in reverse 1 .. Last_I loop
+            if I < Last_I then
+               -- IN PROGRESS: Use gamma for discounting in the following
+               SAR_Array(I).Reward := SAR_Array(I).Reward + MC_Config.Discount_Factor * SAR_Array(I + 1).Reward;
+            end if;
+            -- TODO: This is the every-visit approach, need to modify to implement first-visit approach
+            V(SAR_Array(I).State).Total_Reward := V(SAR_Array(I).State).Total_Reward + SAR_Array(I).Reward;
+            V(SAR_Array(I).State).Count        := V(SAR_Array(I).State).Count + 1;
+         end loop;
+      end Every_Visit_Reward_Update;
+      
+      procedure First_Visit_Reward_Update(V : in out State_Reward_Tracker_Type; SAR_Array_Input : SAR_Array_Type; Last_I : Natural) is
+         SAR_Array : SAR_Array_Type := SAR_Array_Input; -- A local copy to avoid specifying "in out" for the array parameter
+
+         type First_Visit_Array_Type is array(Discrete_Observation_Type) of Natural;
+         First_Visit_Array : First_Visit_Array_Type := (others => 0);
+
+         First_Visit : Natural;
+      begin
+         for I in reverse 1 .. Last_I loop
+            if I < Last_I then
+               SAR_Array(I).Reward := SAR_Array(I).Reward + MC_Config.Discount_Factor * SAR_Array(I + 1).Reward;
+            end if;
+            First_Visit_Array(SAR_Array(I).State) := I;
+         end loop;
+         for S in Discrete_Observation_Type loop
+            if First_Visit_Array(S) > 0 then
+               First_Visit := First_Visit_Array(S);
+               V(SAR_Array(First_Visit).State).Total_Reward := V(SAR_Array(First_Visit).State).Total_Reward + SAR_Array(First_Visit).Reward;
+               V(SAR_Array(First_Visit).State).Count        := V(SAR_Array(First_Visit).State).Count + 1;
+            end if;
+         end loop;
+      end First_Visit_Reward_Update;
+   begin
+      for Episode in 1 .. MC_Config.Num_Episodes loop
+         Obs := Reset(Env);
+         Discrete_Obs := To_Discrete_Observation(Obs);
+         Terminated := False;
+         Last_I := 1;
+         Cumulative_Reward := 0.0;  -- TODO: What is this?
+         for I in 1 .. 21 loop
+            Action := Policy(Discrete_Obs);
+            Step_Output := Step(Env, Action);
+            SAR_Array(I) := (State => Discrete_Obs, Action => Action, Reward => Step_Output.Reward);
+            Discrete_Obs := To_Discrete_Observation(Step_Output.Observation);
+            Last_I := I;
+            Terminated := Step_Output.Terminated;
+            exit when Terminated;
+         end loop;
+
+         -- for I in reverse 1 .. Last_I loop
+         --    if I < Last_I then
+         --       -- IN PROGRESS: Use gamma for discounting in the following
+         --       SAR_Array(I).Reward := SAR_Array(I).Reward + MC_Config.Discount_Factor * SAR_Array(I + 1).Reward;
+         --    end if;
+         --    -- TODO: This is the every-visit approach, need to modify to implement first-visit approach
+         --    V(SAR_Array(I).State).Total_Reward := V(SAR_Array(I).State).Total_Reward + SAR_Array(I).Reward;
+         --    V(SAR_Array(I).State).Count        := V(SAR_Array(I).State).Count + 1;
+         -- end loop;
+         case MC_Config.Visit_Type is
+            when First_Visit =>
+               First_Visit_Reward_Update(V, SAR_Array, Last_I);
+            when Every_Visit =>
+               Every_Visit_Reward_Update(V, SAR_Array, Last_I);
+         end case;
+      end loop;
+
+      return Res : Value_Function_Type := (others => 0.0) do
+         for S in Discrete_Observation_Type loop
+            if V(S).Count > 0 then
+               Res(S) := V(S).Total_Reward / Float(V(S).Count);
+            end if;
+         end loop;
+      end return;
+      
+   end MC_Policy_Evaluation;
+   
+   MC_PE_Config : MC_Config_Type := (Num_Episodes => 50 * 1000000, Visit_Type => First_Visit, Discount_Factor => 1.0);
+   Temp_Policy : Policy_Type := (others => Stick); -- IN PROGRESS: This is a pretty bad policy, need to implement a better one
+   Value_Function : Value_Function_Type;
+   Stick_Level : constant Natural := 17;
+  
+   type State_Action_Value_Type is array (Discrete_Observation_Type, Action_Type) of Float;
+   type Evaluation_Results_Type is record
+      Q: State_Action_Value_Type;
+      Policy : Policy_Type;
+   end record;
+
+   -- TODO: Should we use MC_Config_Type?  We might not want to allow the Every_Visit option.
+   function MC_Exploring_Starts_Evaluation(MC_Config : MC_Config_Type) return Evaluation_Results_Type is
+      type Reward_Tracker_Type is record
+         Total_Reward : Long_Float;  -- TODO: Using Long_Float to see what happens
+         Count : Integer;
+      end record;
+
+      type State_Action_Reward_Tracker_Type is array(Discrete_Observation_Type, Action_Type) of Reward_Tracker_Type;
+      State_Action_Reward_Tracker : State_Action_Reward_Tracker_Type := (others => (others => (0.0, 0)));
+
+       type SAR_Type is record
+         State : Discrete_Observation_Type;
+         Action : Action_Type;
+         Reward : Float;
+      end record;
+
+      type SAR_Array_Type is array (1 .. 21) of SAR_Type;
+      SAR_Array : SAR_Array_Type;
+   
+      package Action_Random is new Ada.Numerics.Discrete_Random(Result_Subtype => Action_Type);
+      Action_Gen : Action_Random.Generator;
+
+      -- NOTE: The flag for indicating whether a state was encountered in an episode
+      --        doesn't impact the results.  At best it reduces the number of states
+      --        for which to update action values and the policy.
+      type State_Encountered_Flag_Type is array(Discrete_Observation_Type) of Boolean;
+      State_Encountered_Flag : State_Encountered_Flag_Type;
+
+      Prev_Policy : Policy_Type;
+      Policy : Policy_Type := (others => Stick);
+      Q : State_Action_Value_Type := (others => (others => 0.0));
+      
+      Env : Environment_Type := Make(Config_Type'(Natural_Win_Reward => SAB, Auto_Hit => True));
+      Obs : Observation_Type;
+      Step_Output : Step_Return_Type;
+      Discrete_Obs : Discrete_Observation_Type;
+      Action : Action_Type;
+      Terminated : Boolean;
+      Last_I : Natural;
+      Stable : Boolean;
+      
+      procedure First_Visit_Reward_Update(Q_Tracker: in out State_Action_Reward_Tracker_Type; SAR_Array_Input : SAR_Array_Type; Last_I : Natural) is
+         SAR_Array : SAR_Array_Type := SAR_Array_Input; -- A local copy to avoid specifying "in out" for the array parameter
+
+         type First_Visit_Array_Type is array(Discrete_Observation_Type) of Natural;
+         First_Visit_Array : First_Visit_Array_Type := (others => 0);
+
+         -- Local variables
+         -- First visit index
+         First_Visit : Natural;
+         A : Action_Type;
+      begin
+         for I in reverse 1 .. Last_I loop
+            if I < Last_I then
+               SAR_Array(I).Reward := SAR_Array(I).Reward + MC_Config.Discount_Factor * SAR_Array(I + 1).Reward;
+            end if;
+            First_Visit_Array(SAR_Array(I).State) := I;
+         end loop;
+         for S in Discrete_Observation_Type loop
+            if First_Visit_Array(S) > 0 then
+               First_Visit := First_Visit_Array(S);
+               A := SAR_Array(First_Visit).Action;
+               -- NOTE: SAR_Array(First_Visit).State should equal S
+               Q_Tracker(S, A).Total_Reward := Q_Tracker(S, A).Total_Reward + Long_Float(SAR_Array(First_Visit).Reward);  -- TODO: Using Long_Float
+               Q_Tracker(S, A).Count        := Q_Tracker(S, A).Count + 1;
+            end if;
+         end loop;
+      end First_Visit_Reward_Update;
+
+      function Update_Policy(Q : State_Action_Value_Type; Prev_Policy: Policy_Type; State_Encountered_Flag: State_Encountered_Flag_Type) return Policy_Type is
+         Res : Policy_Type := Prev_Policy;  -- Copy previous policy
+         Best_Action : Action_Type;
+         Max_Value : Float;
+      begin
+         for S in Discrete_Observation_Type loop
+            -- Only update the policies for those states that appear in the episode
+            if State_Encountered_Flag(S) then
+               Max_Value := Float'First;
+               Best_Action := Action_Type'First;
+               for A in Action_Type loop
+                  if Q(S, A) > Max_Value then
+                     Max_Value := Q(S, A);
+                     Best_Action := A;
+                  end if;
+               end loop;
+               Res(S) := Best_Action;
+            end if;
+         end loop;
+         return Res;
+      end Update_Policy;
+
+   begin
+      Action_Random.Reset(Action_Gen);
+      for Episode in 1 .. MC_Config.Num_Episodes loop
+         -- Exploring starts
+         -- Initialize Env and select a random action.
+         -- TODO: Random selection of env and action might need to be generalized
+         State_Encountered_Flag := (others => False);
+         Obs := Reset(Env);
+         Action := Action_Random.Random(Action_Gen);
+
+         -- Process the first action
+         Discrete_Obs := To_Discrete_Observation(Obs);
+         Step_Output := Step(Env, Action);
+         SAR_Array(1) := (State => Discrete_Obs, Action => Action, Reward => Step_Output.Reward);
+         State_Encountered_Flag(Discrete_Obs) := True;
+         Last_I := 1;
+         Terminated := Step_Output.Terminated;
+
+         if not Terminated then
+            Discrete_Obs := To_Discrete_Observation(Step_Output.Observation);
+
+            -- Simulate as before starting from step 2
+            for I in 2 .. 21 loop
+               Action := Policy(Discrete_Obs);
+               Step_Output := Step(Env, Action);
+               SAR_Array(I) := (State => Discrete_Obs, Action => Action, Reward => Step_Output.Reward);
+               State_Encountered_Flag(Discrete_Obs) := True;
+               Last_I := I;
+               Terminated := Step_Output.Terminated;
+               exit when Terminated;
+               Discrete_Obs := To_Discrete_Observation(Step_Output.Observation);
+            end loop;
+         end if;
+
+         -- For first occurrent of state s and action a, record total reward
+         First_Visit_Reward_Update(State_Action_Reward_Tracker, SAR_Array, Last_I);
+
+         -- Update action values
+         for S in Discrete_Observation_Type loop
+            if State_Encountered_Flag(S) then
+               for A in Action_Type loop
+                  -- if State_Action_Reward_Tracker(S, A).Count) > 0 then -- TODO
+                  Q(S, A) := Float(State_Action_Reward_Tracker(S, A).Total_Reward / Long_Float(State_Action_Reward_Tracker(S, A).Count));  -- TODO: Long_Float
+                  -- end if;
+               end loop;
+            end if;
+         end loop;
+         
+         -- Use arg max to update policy
+         -- Track whether the policy is stable
+         Prev_Policy := Policy;
+         Policy := Update_Policy(Q, Prev_Policy, State_Encountered_Flag);
+         -- TODO: Consider exiting when a stable policy is found.
+         -- Stable := True;
+         -- for S in Discrete_Observation_Type loop
+         --    if Policy(S) /= Prev_Policy(S) then
+         --       Stable := False;
+         --    end if;
+         --    exit when not Stable;
+         -- end loop;
+         -- 
+         -- -- Exit when the policy is stable.
+         -- exit when Stable;
+      end loop;
+      return Evaluation_Results_Type'(Q => Q, Policy => Policy);
+   end MC_Exploring_Starts_Evaluation;
+   
+   Evaluation_Results: Evaluation_Results_Type;
+   
+   type MC_Epsilon_Soft_Config_Type is record
+      Num_Episodes : Integer;
+      -- Visit_Type : MC_Visit_Type;
+      Discount_Factor : Float := 1.0;
+      Epsilon : Float;
+   end record;
+   
+   MC_Epsilon_Soft_Config : MC_Epsilon_Soft_Config_Type := (Num_Episodes => 5 * 1000000, Discount_Factor => 1.0, Epsilon => 0.05);
+
+   -- IN PROGRESS: Should we use MC_Config_Type
+   -- TODO: Should we add a condition so that 1/Action_Count <= 1 - epsilon 
+   --       (which is equivalent to epsilon <= 1 - 1/Action_Count).
+   function MC_Epsilon_Soft_Evaluation(MC_Config : MC_Epsilon_Soft_Config_Type) return Evaluation_Results_Type is
+      type Reward_Tracker_Type is record
+         Total_Reward : Long_Float;  -- TODO: Using Long_Float to see what happens
+         Count : Integer;
+      end record;
+
+      type State_Action_Reward_Tracker_Type is array(Discrete_Observation_Type, Action_Type) of Reward_Tracker_Type;
+      State_Action_Reward_Tracker : State_Action_Reward_Tracker_Type := (others => (others => (0.0, 0)));
+
+       type SAR_Type is record
+         State : Discrete_Observation_Type;
+         Action : Action_Type;
+         Reward : Float;
+      end record;
+
+      type SAR_Array_Type is array (1 .. 21) of SAR_Type;
+      SAR_Array : SAR_Array_Type;
+  
+      package Unif_Random renames Ada.Numerics.Float_Random;
+      Unif_Gen : Unif_Random.Generator;
+
+      type Action_Probability_Type is array (Action_Type) of Float;
+
+      function Get_Random_Action(Action_Probability: Action_Probability_Type) return Action_Type is
+          U : Float := Unif_Random.Random(Unif_Gen);
+          Cum_Prob : Float := 0.0;
+      begin
+          for A in Action_Type loop
+              Cum_Prob := Cum_Prob + Action_Probability(A);
+              if U < Cum_Prob then
+                  return A;
+              end if;
+          end loop;
+          return Action_Type'Last;
+      end Get_Random_Action;
+      
+      function Get_Random_Action(Mixed_Policy: Mixed_Policy_Type; S: Discrete_Observation_Type) return Action_Type is
+         Action_Probability: Action_Probability_Type;
+      begin
+         for A in Action_Type loop
+            Action_Probability(A) := Mixed_Policy(S, A);
+         end loop;
+         return Get_Random_Action(Action_Probability);
+      end Get_Random_Action;
+
+      -- NOTE: For epsilon soft, unlike for exploring starts,
+      --       the flag for indicating whether a state was encountered in an episode
+      --       does have some impact when updating the action values.
+      type State_Encountered_Flag_Type is array(Discrete_Observation_Type) of Boolean;
+      State_Encountered_Flag : State_Encountered_Flag_Type;
+
+      Greedy_Policy : Policy_Type;
+
+      Action_Count : Natural := Action_Type'Pos(Action_Type'Last) - Action_Type'Pos(Action_Type'First) + 1;
+      -- Prev_Policy : Mixed_Policy_Type;
+      Mixed_Policy : Mixed_Policy_Type := (others => (others => 1.0 / Float(Action_Count)));  -- TODO: Is this what we want?
+      Q : State_Action_Value_Type := (others => (others => 0.0));
+      
+      Env : Environment_Type := Make(Config_Type'(Natural_Win_Reward => SAB, Auto_Hit => True));
+      Obs : Observation_Type;
+      Step_Output : Step_Return_Type;
+      Discrete_Obs : Discrete_Observation_Type;
+      Action : Action_Type;
+      Terminated : Boolean;
+      Last_I : Natural;
+      Stable : Boolean;
+     
+      -- TODO: The following is identical to the version defined above, so it might make sense
+      --       to promote this function.
+      procedure First_Visit_Reward_Update(Q_Tracker: in out State_Action_Reward_Tracker_Type; SAR_Array_Input : SAR_Array_Type; Last_I : Natural) is
+         SAR_Array : SAR_Array_Type := SAR_Array_Input; -- A local copy to avoid specifying "in out" for the array parameter
+
+         type First_Visit_Array_Type is array(Discrete_Observation_Type) of Natural;
+         First_Visit_Array : First_Visit_Array_Type := (others => 0);
+
+         -- Local variables
+         -- First visit index
+         First_Visit : Natural;
+         A : Action_Type;
+      begin
+         for I in reverse 1 .. Last_I loop
+            if I < Last_I then
+               SAR_Array(I).Reward := SAR_Array(I).Reward + MC_Config.Discount_Factor * SAR_Array(I + 1).Reward;
+            end if;
+            First_Visit_Array(SAR_Array(I).State) := I;
+         end loop;
+         for S in Discrete_Observation_Type loop
+            if First_Visit_Array(S) > 0 then
+               First_Visit := First_Visit_Array(S);
+               A := SAR_Array(First_Visit).Action;
+               -- NOTE: SAR_Array(First_Visit).State should equal S
+               Q_Tracker(S, A).Total_Reward := Q_Tracker(S, A).Total_Reward + Long_Float(SAR_Array(First_Visit).Reward);  -- TODO: Using Long_Float
+               Q_Tracker(S, A).Count        := Q_Tracker(S, A).Count + 1;
+            end if;
+         end loop;
+      end First_Visit_Reward_Update;
+
+      function Best_Policy(Q : State_Action_Value_Type) return Policy_Type is
+         Res : Policy_Type;
+         Best_Action : Action_Type;
+         Max_Value : Float;
+      begin
+         for S in Discrete_Observation_Type loop
+            Max_Value := Float'First;
+            Best_Action := Action_Type'First;
+            for A in Action_Type loop
+               if Q(S, A) > Max_Value then
+                  Max_Value := Q(S, A);
+                  Best_Action := A;
+               end if;
+            end loop;
+            Res(S) := Best_Action;
+         end loop;
+         return Res;
+      end Best_Policy;
+
+      function Epsilon_Soft_Policy_Update (MC_Config : MC_Epsilon_Soft_Config_Type; Mixed_Policy_Prev: Mixed_Policy_Type; Policy: Policy_Type; State_Encountered_Flag: State_Encountered_Flag_Type) return Mixed_Policy_Type is
+         Best_Action : Action_Type;
+         Mixed_Policy : Mixed_Policy_Type := Mixed_Policy_Prev;
+         Eps : Float := MC_Config.Epsilon;
+      begin
+         for S in Discrete_Observation_Type loop
+            if State_Encountered_Flag(S) then
+               Best_Action := Policy(S);
+               for A in Action_Type loop
+                  if A = Best_Action then
+                     Mixed_Policy(S, A) := 1.0 - Eps + Eps / Float(Action_Count);
+                  else
+                     Mixed_Policy(S, A) := Eps / Float(Action_Count);
+                  end if;
+               end loop;
+            end if;
+         end loop;
+         return Mixed_Policy;
+      end Epsilon_Soft_Policy_Update;
+   begin
+      Unif_Random.Reset(Unif_Gen);
+      for Episode in 1 .. MC_Config.Num_Episodes loop
+         -- Initialize Env and select a random action.
+         State_Encountered_Flag := (others => False);
+         Obs := Reset(Env);
+         for I in 1 .. 21 loop
+            Discrete_Obs := To_Discrete_Observation(Obs);
+            Action := Get_Random_Action(Mixed_Policy, Discrete_Obs);
+            -- Put_Line("Using action: " & Action_Type'Image(Action));  -- TODO Verbose
+            Step_Output := Step(Env, Action);
+            SAR_Array(I) := (State => Discrete_Obs, Action => Action, Reward => Step_Output.Reward);
+            Last_I := I;
+            State_Encountered_Flag(Discrete_Obs) := True;
+            Terminated := Step_Output.Terminated;
+            exit when Terminated;
+            -- Set state to next state
+            Discrete_Obs := To_Discrete_Observation(Step_Output.Observation);
+         end loop;
+
+         -- For first occurrent of state s and action a, record total reward
+         First_Visit_Reward_Update(State_Action_Reward_Tracker, SAR_Array, Last_I);
+
+         -- Update action values
+         for S in Discrete_Observation_Type loop
+            -- TODO: Do we want to put a conditional on State_Encountered_Flag(S)?
+            for A in Action_Type loop
+               if State_Action_Reward_Tracker(S, A).Count > 0 then
+                  Q(S, A) := Float(State_Action_Reward_Tracker(S, A).Total_Reward / Long_Float(State_Action_Reward_Tracker(S, A).Count));  -- TODO: Long_Float
+               -- else  -- NOTE: a default of -1, will likely get rid of this as there's no real impact
+               --    Q(S, A) := -1.0;
+               end if;
+            end loop;
+         end loop;
+         
+         -- Use arg max to update policy
+         -- Track whether the policy is stable
+         -- Prev_Policy := Policy;
+         Greedy_Policy := Best_Policy(Q);
+         Mixed_Policy := Epsilon_Soft_Policy_Update (MC_Config, Mixed_Policy, Greedy_Policy, State_Encountered_Flag);
+         -- TODO: Consider what an exit for an epsilon-soft on-policy evaluation might look like.
+         -- Stable := True;
+         -- for S in Discrete_Observation_Type loop
+         --    if Policy(S) /= Prev_Policy(S) then
+         --       Stable := False;
+         --    end if;
+         --    exit when not Stable;
+         -- end loop;
+         -- 
+         -- -- Exit when the policy is stable.
+         -- exit when Stable;
+      end loop;
+      return Evaluation_Results_Type'(Q => Q, Policy => Greedy_Policy);
+   end MC_Epsilon_Soft_Evaluation;
+
+   procedure Print_Evaluation_Results(Evaluation_Results: Evaluation_Results_Type) is
+   begin
+      for Temp_Useable_Ace in 0 .. 1 loop
+         Put_Line("Usable Ace: " & Boolean'Image(Boolean'Val(Temp_Useable_Ace)));
+         Put("    ");
+         for Temp_Dealer_Showing_Value in 1 .. 10 loop
+            Put(Temp_Dealer_Showing_Value, Width => 8);
+         end loop;
+         New_Line;
+
+         for Temp_Player_Sum in 12 .. 21 loop
+            Put(Temp_Player_Sum, Width => 2);
+            Put(": ");
+            for Temp_Dealer_Showing_Value in 1 .. 10 loop
+               declare
+                  A : Action_Type := Evaluation_Results.Policy(
+                     Discrete_Observation_Type(Temp_Useable_Ace * 10 * 10 + (Temp_Player_Sum - 12) * 10 + (Temp_Dealer_Showing_Value - 1))
+                  );
+               begin
+                  case A is
+                     when HIT =>
+                        Put("     HIT");
+                     when STICK =>
+                        Put("   STICK");
+                  end case;
+               end;
+            end loop;
+            New_Line;
+         end loop;
+      end loop;
+   end Print_Evaluation_Results;
+begin
+   for Temp_Useable_Ace in 0 .. 1 loop
+      for Temp_Player_Sum in 12 .. 21 loop
+         for Temp_Dealer_Showing_Value in 1 .. 10 loop
+            declare
+               Temp_I : Discrete_Observation_Type := Discrete_Observation_Type(Temp_Useable_Ace * 10 * 10 + (Temp_Player_Sum - 12) * 10 + (Temp_Dealer_Showing_Value - 1));
+            begin
+               if Temp_Player_Sum < Stick_Level then
+                  Temp_Policy(Temp_I) := Hit;
+               else
+                  Temp_Policy(Temp_I) := Stick;
+               end if;
+            end;
+         end loop;
+      end loop;
+   end loop;
+   Put_Line("Starting Monte Carlo Policy Evaluation");
+   Put_Line("Last element of Discrete_Observation_Type: " & Discrete_Observation_Type'Image(Discrete_Observation_Type'Last));
+   -- Put_Line("Last element of Discrete_Observation_Type2: " & Discrete_Observation_Type2'Image(Discrete_Observation_Type2'Last));
+   -- Put_Line("Element after last element of Discrete_Observation_Type2: " & Discrete_Observation_Type2'Image(Discrete_Observation_Type2'Succ(Discrete_Observation_Type2'Last)));
+   Value_Function := MC_Policy_Evaluation(Temp_Policy, MC_PE_Config);
+   for S in Discrete_Observation_Type loop
+      Put_Line("Value for state " & Discrete_Observation_Type'Image(S) & ": " & Float'Image(Value_Function(S)));
+   end loop;
+   -- Put_Line(State_Value_Map.Is_Empty'Image);
+   -- for I in 2 .. 21 loop
+   --    State_Value_Map.Insert(
+   --       Key => Observation_Type'(Player_Sum => I, Dealer_Showing_Card => Card_Type'First, Usable_Ace => False),
+   --       New_Item => Float(I));
+   -- end loop;
+   -- for I in 2 .. 21 loop
+   --    declare
+   --       Value : Float;
+   --    begin
+   --       Value := State_Value_Map.Element(
+   --          Observation_Type'(Player_Sum => I, Dealer_Showing_Card => Card_Type'First, Usable_Ace => False)
+   --       );
+   --       Put_Line("Value for player sum " & Integer'Image(I) & ": " & Float'Image(Value));
+   --    end;
+   -- end loop;
+   Put_Line("Policy Evaluation Results (100 * Reward):");
+   for Temp_Useable_Ace in 0 .. 1 loop
+      Put_Line("Usable Ace: " & Boolean'Image(Boolean'Val(Temp_Useable_Ace)));
+      Put("    ");
+      for Temp_Dealer_Showing_Value in 1 .. 10 loop
+         Put(Temp_Dealer_Showing_Value, Width => 8);
+      end loop;
+      New_Line;
+
+      for Temp_Player_Sum in 12 .. 21 loop
+         Put(Temp_Player_Sum, Width => 2);
+         Put(": ");
+         for Temp_Dealer_Showing_Value in 1 .. 10 loop
+            Put(100.0 * Value_Function(Discrete_Observation_Type(Temp_Useable_Ace * 10 * 10 + (Temp_Player_Sum - 12) * 10 + (Temp_Dealer_Showing_Value - 1))), Fore => 5, Aft => 2, Exp => 0);
+         end loop;
+         New_Line;
+      end loop;
+   end loop;
+
+   -- TODO: The results don't seem to match the book perfectly, even when using
+   --       50 million episodes.  This implementation will need to be reviewed.
+   -- Evaluation_Results_Type 
+   Put_Line("MC Exploring Starts");
+   Put_Line("Number of episodes: " & Integer'Image(MC_PE_Config.Num_Episodes));
+   Evaluation_Results := MC_Exploring_Starts_Evaluation(MC_PE_Config);
+   Print_Evaluation_Results(Evaluation_Results);
+
+   -- Put_Line("MC Epsilon Soft on-policy evaluation");
+   -- Put_Line("Number of episodes: " & Integer'Image(MC_Epsilon_Soft_Config.Num_Episodes));
+   -- Evaluation_Results := MC_Epsilon_Soft_Evaluation(MC_Epsilon_Soft_Config);
+   -- Print_Evaluation_Results(Evaluation_Results);
+
+end MC_Policy_Evaluation_Example;


### PR DESCRIPTION
Adding preliminary Monte Carlo techniques for policy and action value estimation.  The methods are only implemented for blackjack at this point.