### PR TITLE
Generic Step Return

### DIFF
--- a/experiments/ada/rl-examples/src/frozenlake_example.adb
+++ b/experiments/ada/rl-examples/src/frozenlake_example.adb
@@ -3,6 +3,7 @@ with Ada.Float_Text_IO;
 with RL.Envs.Frozenlake; use RL.Envs.Frozenlake;
 with RL.Envs.Frozenlake.Child;
 with RL.Algorithms.Random_Actions;
+-- with RL.Envs.Step_Return;
 
 procedure Main is
     Config: Environment_Config := Environment_Config'(Map_Name => Map_4x4, Slippery => False);
@@ -10,9 +11,10 @@ procedure Main is
     package Frozenlake_Child is new RL.Envs.Frozenlake.Child(Map_Info => Get_Map_Info(Map_4x4));
     DP_Model : Discrete_Model_Type := Get_Model(Environment_Config'(Map_Name => Map_4x4, Slippery => False));
    
-   function Get_Observation (Step_Return : Step_Return_Type) return Observation_Type is (Step_Return.State);
-   function Get_Reward(Step_Return : Step_Return_Type) return Float is (Step_Return.Reward);
-   function Get_Terminated_Flag(Step_Return : Step_Return_Type) return Boolean is (Step_Return.Terminated);
+   -- function Get_Observation (Step_Return : Step_Return_Type) return Observation_Type is (Step_Return.State);
+   -- function Get_Reward(Step_Return : Step_Return_Type) return Float is (Step_Return.Reward);
+   -- function Get_Terminated_Flag(Step_Return : Step_Return_Type) return Boolean is (Step_Return.Terminated);
+   -- package SR2 is new RL.Envs.Step_Return (Observation_Type => Observation_Type);
    package Frozenlake_Random_Actions is new RL.Algorithms.Random_Actions(
        Config_Type => Environment_Config,
        Environment_Type => Environment_State,
@@ -21,16 +23,19 @@ procedure Main is
        Step_Return_Type => Step_Return_Type,
        Make => Make,
        Reset => Reset,
-       Step => Step,
-       Get_Observation => Get_Observation,
-       Get_Reward => Get_Reward,
-       Get_Terminated_Flag => Get_Terminated_Flag
+       -- This is from RL.Envs.Frozenlake, must use the same package
+       -- used to define Step_Return_Type
+       SR => Frozenlake_Step_Return, 
+       Step => Step -- ,
+       -- Get_Observation => Get_Observation,
+       -- Get_Reward => Get_Reward,
+       -- Get_Terminated_Flag => Get_Terminated_Flag
     );
     Sim_Summary : Frozenlake_Random_Actions.Simulation_Summary;
 
 begin
    Sim_Summary := Frozenlake_Random_Actions.Uniform_Random_Actions (Config, True);
-   Put_Line("Simulation summary using generic package:");
+   Put_Line("Simulation summary using generic package and step return template:");
    Put_Line("  Number of steps: " & Natural'Image (Sim_Summary.Num_Steps));
    Put("  Total reward: ");
    Ada.Float_Text_IO.Put(Item => Sim_Summary.Total_Reward, Fore => 2, Aft => 2, Exp => 0);

--- a/experiments/ada/rl/src/rl-algorithms-random_actions.ads
+++ b/experiments/ada/rl/src/rl-algorithms-random_actions.ads
@@ -1,19 +1,25 @@
+with RL.Envs.Step_Return;
 
 generic
    type Config_Type is private;
    type Environment_Type (<>) is limited private;
    type Observation_Type is private;
    type Action_Type is (<>);
-   type Step_Return_Type is private;
+   -- type Step_Return_Type is private;
+   with package SR is new RL.Envs.Step_Return (Observation_Type => Observation_Type);
+   type Step_Return_Type is new SR.Step_Return_Type;
    
    with function Make(Config: Config_Type) return Environment_Type;
    with function Reset(Env : in out Environment_Type) return Observation_Type;
    with function Step(Env : in out Environment_Type; action: Action_Type) return Step_Return_Type;
    
-   with function Get_Observation (Step_Return : Step_Return_Type) return Observation_Type;
-   with function Get_Reward(Step_Return : Step_Return_Type) return Float;
-   with function Get_Terminated_Flag(Step_Return : Step_Return_Type) return Boolean;
+   -- with function Get_Observation (Step_Return : Step_Return_Type) return Observation_Type;
+   -- with function Get_Reward(Step_Return : Step_Return_Type) return Float;
+   -- with function Get_Terminated_Flag(Step_Return : Step_Return_Type) return Boolean;
 package RL.Algorithms.Random_Actions is
+   function Get_Observation (Step_Return : Step_Return_Type) return Observation_Type is (Step_Return.State);
+   function Get_Reward(Step_Return : Step_Return_Type) return Float is (Step_Return.Reward);
+   function Get_Terminated_Flag(Step_Return : Step_Return_Type) return Boolean is (Step_Return.Terminated);
 
    type Simulation_Summary is record
        Num_Steps : Natural;

--- a/experiments/ada/rl/src/rl-envs-frozenlake.ads
+++ b/experiments/ada/rl/src/rl-envs-frozenlake.ads
@@ -1,6 +1,7 @@
 with Ada.Text_IO; use Ada.Text_IO;
 with Ada.Numerics;
 with Ada.Numerics.Float_Random;
+with RL.Envs.Step_Return;
 
 package RL.Envs.Frozenlake is
    package Float_Random renames Ada.Numerics.Float_Random;
@@ -32,12 +33,14 @@ package RL.Envs.Frozenlake is
       Position_Index : Natural;
    end record;
     
-   type Step_Return_Type is record
-      State: Observation_Type; -- TODO: Change variable name to Observation
-      Reward: Float;
-      Terminated: Boolean;
-      Done: Boolean; -- TODO: Change variable name to Truncated to match Python implementation
-   end record;
+   -- type Step_Return_Type is record
+   --    State: Observation_Type; -- TODO: Change variable name to Observation
+   --    Reward: Float;
+   --    Terminated: Boolean;
+   --    Done: Boolean; -- TODO: Change variable name to Truncated to match Python implementation
+   -- end record;
+   package Frozenlake_Step_Return is new RL.Envs.Step_Return (Observation_Type => Observation_Type);
+   subtype Step_Return_Type is Frozenlake_Step_Return.Step_Return_Type;
     
    function Make(config: Environment_Config) return Environment_State;
    -- TODO: Add argument for seed

--- a/experiments/ada/rl/src/rl-envs-step_return.ads
+++ b/experiments/ada/rl/src/rl-envs-step_return.ads
@@ -1,0 +1,12 @@
+generic
+   type Observation_Type is private;
+package RL.Envs.Step_Return is
+
+   type Step_Return_Type is record
+      State: Observation_Type;
+      Reward: Float;
+      Terminated: Boolean;
+      Done : Boolean;
+   end record;
+
+end RL.Envs.Step_Return;


### PR DESCRIPTION
We add a generic package for defining the step returns, and use subtypes of the generic step return in the environments such as frozenlake.  The benefit of this approach is it allows access to the members of the step return instances.   The drawback is some complexity when setting up generic packages for algorithms.

We will likely revert to a simpler approach, and simply pass methods to the generic algorithms for accessing the step returns.