### PR TITLE
RL Ada Cliffwalking improvements

### DIFF
--- a/experiments/ada/rl/reinforcement_learning.gpr
+++ b/experiments/ada/rl/reinforcement_learning.gpr
@@ -4,7 +4,7 @@ project Reinforcement_Learning is
    for Library_Name use "Reinforcement_Learning";
    for Library_Version use Project'Library_Name & ".so." & Reinforcement_Learning_Config.Crate_Version;
 
-   for Source_Dirs use ("src/", "config/");
+   for Source_Dirs use ("src/", "config/", "third_party/");
    for Object_Dir use "obj/" & Reinforcement_Learning_Config.Build_Profile;
    for Create_Missing_Dirs use "True";
    for Library_Dir use "lib";

--- a/experiments/ada/rl/src/rl-algorithms-random_actions.adb
+++ b/experiments/ada/rl/src/rl-algorithms-random_actions.adb
@@ -7,7 +7,7 @@ package body RL.Algorithms.Random_Actions is
    function Uniform_Random_Actions (Config : Config_Type; Verbose : Boolean) return Simulation_Summary is
       package Action_Random is new Ada.Numerics.Discrete_Random(Result_Subtype => Action_Type);
       Gen: Action_Random.Generator;
-      Seed_Reset : Seed_Reset_Type := Seed_Reset_Type'(Kind => Set_Default);
+      -- Seed_Reset : Seed_Reset_Type := Seed_Reset_Type'(Kind => Set_Default);
       Env : Environment_Type := Make(Config);
       Obs: Observation_Type;
       Action: Action_Type;
@@ -15,7 +15,12 @@ package body RL.Algorithms.Random_Actions is
       I: Integer;
       Total_Reward: Float := 0.0;
    begin
-      Action_Random.Reset(Gen);
+      -- For reproducibility we use the Seed_Reset generic parameter to reset the action generator.
+      case Seed_Reset.Kind is
+         when Set_Default => Action_Random.Reset(Gen);
+         when No_Set      => null;
+         when Set_Seed    => Action_Random.Reset(Gen, Seed_Reset.Seed);
+      end case;
 
       Obs:= Reset(Env, Seed_Reset);
       I := 0;

--- a/experiments/ada/rl/src/rl-algorithms-random_actions.ads
+++ b/experiments/ada/rl/src/rl-algorithms-random_actions.ads
@@ -12,6 +12,8 @@ generic
    with function Get_Observation (Step_Return : Step_Return_Type) return Observation_Type;
    with function Get_Reward(Step_Return : Step_Return_Type) return Float;
    with function Get_Terminated_Flag(Step_Return : Step_Return_Type) return Boolean;
+
+   Seed_Reset : Seed_Reset_Type := (Kind => Set_Default);
 package RL.Algorithms.Random_Actions is
 
    type Simulation_Summary is record

--- a/experiments/ada/rl/src/rl-envs-carrental.adb
+++ b/experiments/ada/rl/src/rl-envs-carrental.adb
@@ -1,7 +1,8 @@
+with Ada.Text_IO; use Ada.Text_IO;
 with Ada.Numerics.Generic_Elementary_Functions;
 
 
-package body Car_Rental is
+package body RL.Envs.Carrental is
    package Math is new Ada.Numerics.Generic_Elementary_Functions(Float);
 
    function Poisson_PMF(Lambda : Float; N : Natural) return Float is
@@ -492,5 +493,4 @@ package body Car_Rental is
       return Calculate_Transition_Probability2(Config, Cars_After_Action.Cars_Moved, Cars_Count1);
    end Get_Transition_Values2;
 
-end Car_Rental;
-
+end RL.Envs.Carrental;

--- a/experiments/ada/rl/src/rl-envs-carrental.ads
+++ b/experiments/ada/rl/src/rl-envs-carrental.ads
@@ -1,12 +1,11 @@
-with Ada.Text_IO; use Ada.Text_IO;
-with Ada.Numerics;
-with Ada.Numerics.Float_Random; -- use Ada.Numerics.Float_Random;
-with Generic_Random_Functions;
+-- with Ada.Numerics;
+with Ada.Numerics.Float_Random;
+with Mathpaqs.Generic_Random_Functions;
 with System.Pool_Local;
 
-package Car_Rental is
+package RL.Envs.Carrental is
    package Float_Random renames Ada.Numerics.Float_Random;
-   package GRF is new Generic_Random_Functions(Real => Float);
+   package GRF is new Mathpaqs.Generic_Random_Functions(Real => Float);
 
    Lot_Size : constant Positive := 20;
    Max_Move : constant Positive := 5;
@@ -130,5 +129,5 @@ private
    function Step_Cars(Cars_Count : Cars_Per_Lot_Type; Action : Action_Type) return Cars_After_Action_Type;
    function Calculate_Transition_Probability2 (Config : Environment_Config; Cars_Moved : Natural; Prev_Cars : Cars_Per_Lot_Type) return Transition_Array_Type;
 
-end Car_Rental;
+end RL.Envs.Carrental;
 

--- a/experiments/ada/rl/src/rl-envs-cliffwalking.adb
+++ b/experiments/ada/rl/src/rl-envs-cliffwalking.adb
@@ -1,3 +1,4 @@
+with Ada.Text_IO; use Ada.Text_IO;
 -- from gymnasium import Env, spaces
 -- from gymnasium.envs.toy_text.utils import categorical_sample
 
@@ -185,23 +186,24 @@ package body RL.Envs.Cliffwalking is
       Result : Step_Return_Type := (
          Observation => To_S(Env.Map, Transition.Position),
          Reward => Transition.Reward,
-         Terminated => Transition.Terminated,
-         Truncated => False
+         Terminated => Transition.Terminated
       );
    begin
       -- Update the Agent's position based on the transition
       Env.Agent_Position := Transition.Position;
-      -- TODO: Consider whether to return info {"prob": p}
       return Result;
    end Step;
 
-   function Reset(Env : in out Environment_State) return Observation_Type is
+   function Reset(Env : in out Environment_State; Seed_Reset : Seed_Reset_Type) return Observation_Type is
       Result : Observation_Type;
    begin
-      Float_Random.Reset(Gen);
+      case Seed_Reset.Kind is
+         when Set_Default => Float_Random.Reset(Gen);
+         when No_Set      => null;
+         when Set_Seed    => Float_Random.Reset(Gen, Seed_Reset.Seed);
+      end case;
       Env.Agent_Position := Get_Start_Position(Env.Map);
       Result := To_S(Env.Map, Env.Agent_Position);
-      -- TODO: In the Python version, the info returned is {"prob": 1}
       return Result;
    end Reset;
 

--- a/experiments/ada/rl/src/rl-envs-cliffwalking.adb
+++ b/experiments/ada/rl/src/rl-envs-cliffwalking.adb
@@ -112,9 +112,9 @@ package body RL.Envs.Cliffwalking is
                for A in Action_Type loop
                   for A_Act in Action_Type loop
                      if A = A_Act then
-                        P(I, J)(A, A_Act) := (Probability => 1.0, Position => (Row => I, Col => J), Reward => 0.0, Terminated => True);
+                        P(I, J, A, A_Act) := (Probability => 1.0, Position => (Row => I, Col => J), Reward => 0.0, Terminated => True);
                      else
-                        P(I, J)(A, A_Act) := (Probability => 0.0, Position => (Row => I, Col => J), Reward => 0.0, Terminated => True);
+                        P(I, J, A, A_Act) := (Probability => 0.0, Position => (Row => I, Col => J), Reward => 0.0, Terminated => True);
                      end if;
                   end loop;
                end loop;
@@ -135,7 +135,7 @@ package body RL.Envs.Cliffwalking is
                            Temp_Probability := 0.0;
                         end if;
                      end if;
-                     P(I, J)(A, A_Actual) := (
+                     P(I, J, A, A_Actual) := (
                         Probability => Temp_Probability,
                         Position => Temp_Partial_Transition.Position,
                         Reward => Temp_Partial_Transition.Reward,
@@ -148,7 +148,7 @@ package body RL.Envs.Cliffwalking is
       end loop;
       
       return (
-         Map => Map, P => P, Agent_Position => Start_Position
+         Map => Map, P => P, Agent_Position => Start_Position, Gen => <>
       );
    end Make;
    
@@ -165,27 +165,29 @@ package body RL.Envs.Cliffwalking is
          Temp_Cumulative_Probability : Float := 0.0;
       begin
          for A_Act in Action_Type loop
-            Cumulative_Probability(A_Act) := P(I, J)(Action, A_Act).Probability + Temp_Cumulative_Probability;
+            Cumulative_Probability(A_Act) := P(I, J, Action, A_Act).Probability + Temp_Cumulative_Probability;
             Temp_Cumulative_Probability := Cumulative_Probability(A_Act);
          end loop;
          return Cumulative_Probability;
       end Get_Cumulative_Probability;
       
-      function Get_Random_Transition(P : Map_Transitions; Position : Position_Type; Action : Action_Type) return Transition_Type is
+      function Get_Random_Transition(Env: in out Environment_Type; Action : Action_Type) return Transition_Type is
+         P : Map_Transitions := Env.P;
+         Position : Position_Type := Env.Agent_Position;
          Cumulative_Probability : Cumulative_Probability_Type := Get_Cumulative_Probability(P, Position, Action);
-         Rand : Float := Float_Random.Random(Gen);
+         Rand : Float := Float_Random.Random(Env.Gen);
       begin
          for A_Act in Action_Type loop
             if Rand <= Cumulative_Probability(A_Act) then
-               return P(Position.Row, Position.Col)(Action, A_Act);
+               return P(Position.Row, Position.Col, Action, A_Act);
             end if;
          end loop;
          -- The following should never be reached as the cumulative probabilities should sum to 1.0
-         return P(Position.Row, Position.Col)(Action, Action_Type'First);
+         return P(Position.Row, Position.Col, Action, Action_Type'First);
       end Get_Random_Transition;
 
       -- Sample to obtain the transition based on the current position and the action taken by the Agent
-      Transition : Transition_Type := Get_Random_Transition(Env.P, Env.Agent_Position, Action);
+      Transition : Transition_Type := Get_Random_Transition(Env, Action);
    begin
       -- Update the Agent's position based on the transition
       Env.Agent_Position := Transition.Position;
@@ -200,9 +202,9 @@ package body RL.Envs.Cliffwalking is
       Result : Observation_Type;
    begin
       case Seed_Reset.Kind is
-         when Set_Default => Float_Random.Reset(Gen);
+         when Set_Default => Float_Random.Reset(Env.Gen);
          when No_Set      => null;
-         when Set_Seed    => Float_Random.Reset(Gen, Seed_Reset.Seed);
+         when Set_Seed    => Float_Random.Reset(Env.Gen, Seed_Reset.Seed);
       end case;
       Env.Agent_Position := Get_Start_Position(Env.Map);
       Result := To_S(Env.Agent_Position);
@@ -239,5 +241,60 @@ package body RL.Envs.Cliffwalking is
          New_Line;
       end loop;
    end Render_Text;
-   
+
+   -- We follow the approach used for Frozenlake
+   function Get_Model(Config: Config_Type) return DP_Model_Type is
+      Res : DP_Model_Type := (others => (others => (others => (Probability => 0.0, Reward => 0.0))));
+      Env : Environment_Type := Make(Config);
+      Prev_State : State_Type;
+      Next_State : State_Type;
+
+      type Expected_Reward_Type is record
+         Probability_Weighted_Reward : Float := 0.0;
+         Total_Probability : Float := 0.0;
+      end record;
+      type Expected_Rewards_Type is array (State_Type) of Expected_Reward_Type;
+
+      Temp_Expected_Rewards : Expected_Rewards_Type;
+
+      Temp_Probability : Float;
+      Temp_Reward : Float;
+   begin
+      for I in Env.P'Range(1) loop
+         for J in Env.P'Range(2) loop
+            Prev_State := State_Type(To_S(Position_Type'(Row => I, Col => J)));
+            for A in Action_Type loop
+               -- When the cliff is slippery, an action can lead to state transitions
+               -- with different probabilities.
+               -- This can be seen when in a corner cell of the map, in which case
+               -- an action that would take you off the board (if there was no slipping)
+               -- will result in arriving at the same cell 2/3 of the time.
+               -- To obtain the correct values, we calculate the conditional expectation for
+               -- the state transitions.
+               -- This should also generalize if we were to consider state transitions with
+               -- non-uniform probabilities.
+               Temp_Expected_Rewards := (others => (Probability_Weighted_Reward => 0.0, Total_Probability => 0.0));
+
+               for A_Act in Action_Type loop
+                  Next_State := State_Type(To_S(Env.P(I, J, A, A_Act).Position));
+                  Temp_Probability := Env.P(I, J, A, A_Act).Probability;
+                  Temp_Reward := Env.P(I, J, A, A_Act).Reward;
+                  Temp_Expected_Rewards(Next_State).Probability_Weighted_Reward := Temp_Expected_Rewards(Next_State).Probability_Weighted_Reward + Temp_Probability * Temp_Reward;
+                  Temp_Expected_Rewards(Next_State).Total_Probability := Temp_Expected_Rewards(Next_State).Total_Probability + Temp_Probability;
+               end loop;
+               -- Now that we've processed the possible transitions and their probabilities for a given action,
+               -- we calculate the discrete transition probabilities and conditional rewards
+               for Next_State in Temp_Expected_Rewards'Range loop
+                  if Temp_Expected_Rewards(Next_State).Total_Probability > 0.0 then
+                     Res(Prev_State, A, Next_State) := (
+                        Probability => Temp_Expected_Rewards(Next_State).Total_Probability,
+                        Reward => Temp_Expected_Rewards(Next_State).Probability_Weighted_Reward / Temp_Expected_Rewards(Next_State).Total_Probability
+                     );
+                  end if;
+               end loop;
+            end loop;
+         end loop;
+      end loop;
+      return Res;
+   end Get_Model;
 end RL.Envs.Cliffwalking;

--- a/experiments/ada/rl/src/rl-envs-cliffwalking.adb
+++ b/experiments/ada/rl/src/rl-envs-cliffwalking.adb
@@ -4,14 +4,16 @@ with Ada.Text_IO; use Ada.Text_IO;
 
 package body RL.Envs.Cliffwalking is
 
-   -- The following is identical to the version in Frozen_Lake
-   function Position_Inc(Rows : Positive; Cols : Positive; Position: Position_Type; Action: Action_Type) return Position_Type is
+   -- The following is similar to the version in Frozen_Lake,
+   -- except that we don't need to provide the number of rows
+   -- and columns as inputs as they are constants in Cliff Walking.
+   function Position_Inc(Position: Position_Type; Action: Action_Type) return Position_Type is
       New_Position : Position_Type := Position;
    begin
       case Action is
          when Left => New_Position.Col := Positive'Max(New_Position.Col - 1, 1);
-         when Down => New_Position.Row := Positive'Min(New_Position.Row + 1, Rows);
-         when Right => New_Position.Col := Positive'Min(New_Position.Col + 1, Cols);
+         when Down => New_Position.Row := Positive'Min(New_Position.Row + 1, Num_Rows);
+         when Right => New_Position.Col := Positive'Min(New_Position.Col + 1, Num_Cols);
          when Up => New_Position.Row := Positive'Max(New_Position.Row - 1, 1);
       end case;
       return New_Position;
@@ -19,7 +21,7 @@ package body RL.Envs.Cliffwalking is
 
    -- The following is adapted from Frozen_Lake with the changes noted in the comments.
    function Update_Probability_Matrix(Map : Map_Array; Position: Position_Type; Action : Action_Type) return Partial_Transition_Type is
-      New_Position : Position_Type := Position_Inc(Map'Length(1), Map'Length(2), Position, Action);
+      New_Position : Position_Type := Position_Inc(Position, Action);
       New_Letter : Map_Element := Map(New_Position.Row, New_Position.Col);
       -- Terminated differs from the approach in Frozen_Lake.  If the agent falls off the cliff,
       -- the agent is sent back to the start with a reward of -100 for the step rather than
@@ -39,15 +41,17 @@ package body RL.Envs.Cliffwalking is
    
    -- We use the approach from Frozen_Lake, except we return an Observation_Type
    -- rather than a Natural, as the Observation_Type is a new Natural.
+   -- We don't provide the Map as an input in Cliff Walking, as in the Frozen Lake
+   -- environment that was used for the number of columns, which is a constant
+   -- in Cliff Walking and is read directly from the package variable.
    -- Note the following is different from the Python implementation as internally we
    -- track the Agent's position using 1-based indexing.
    -- To keep the observations consistent with the Python implementation,
    -- we convert the position to a 0-based index.
-   function To_S(Map: Map_Array; Position: Position_Type) return Observation_Type is
+   function To_S(Position: Position_Type) return Observation_Type is
       Row : Positive := Position.Row;
       Col : Positive := Position.Col;
-      Num_Col : Positive := Map'Length(2);
-      Position_Index : Natural := (Row - 1) * Num_Col + (Col - 1);
+      Position_Index : Natural := (Row - 1) * Num_Cols + (Col - 1);
    begin
       return Observation_Type(Position_Index);
    end To_S;
@@ -78,7 +82,7 @@ package body RL.Envs.Cliffwalking is
       return Start_Position;
    end Get_Start_Position;
 
-   function Make(config: Environment_Config) return Environment_State is
+   function Make(config: Config_Type) return Environment_Type is
       Map : Map_Array := Map_Array'(
                1 .. 3 => (P, P, P, P, P, P, P, P, P, P, P, P),
                4      => (S, C, C, C, C, C, C, C, C, C, C, G));
@@ -148,7 +152,7 @@ package body RL.Envs.Cliffwalking is
       );
    end Make;
    
-   function Step(Env : in out Environment_State; Action: Action_Type) return Step_Return_Type is
+   function Step(Env : in out Environment_Type; Action: Action_Type) return Step_Return_Type is
       -- Helper functions
       type Cumulative_Probability_Type is array (Action_Type) of Float;
       
@@ -182,19 +186,17 @@ package body RL.Envs.Cliffwalking is
 
       -- Sample to obtain the transition based on the current position and the action taken by the Agent
       Transition : Transition_Type := Get_Random_Transition(Env.P, Env.Agent_Position, Action);
-
-      Result : Step_Return_Type := (
-         Observation => To_S(Env.Map, Transition.Position),
-         Reward => Transition.Reward,
-         Terminated => Transition.Terminated
-      );
    begin
       -- Update the Agent's position based on the transition
       Env.Agent_Position := Transition.Position;
-      return Result;
+      return Step_Return_Type'(
+         Observation => To_S(Transition.Position),
+         Reward => Transition.Reward,
+         Terminated => Transition.Terminated
+      );
    end Step;
 
-   function Reset(Env : in out Environment_State; Seed_Reset : Seed_Reset_Type) return Observation_Type is
+   function Reset(Env : in out Environment_Type; Seed_Reset : Seed_Reset_Type) return Observation_Type is
       Result : Observation_Type;
    begin
       case Seed_Reset.Kind is
@@ -203,11 +205,11 @@ package body RL.Envs.Cliffwalking is
          when Set_Seed    => Float_Random.Reset(Gen, Seed_Reset.Seed);
       end case;
       Env.Agent_Position := Get_Start_Position(Env.Map);
-      Result := To_S(Env.Map, Env.Agent_Position);
+      Result := To_S(Env.Agent_Position);
       return Result;
    end Reset;
 
-   procedure Render_Text(Env : Environment_State) is
+   procedure Render_Text(Env : Environment_Type) is
    begin
       for I in Env.Map'Range(1) loop
          for J in Env.Map'Range(2) loop

--- a/experiments/ada/rl/src/rl-envs-cliffwalking.ads
+++ b/experiments/ada/rl/src/rl-envs-cliffwalking.ads
@@ -1,97 +1,76 @@
-with Ada.Text_IO; use Ada.Text_IO;
-with Ada.Numerics;
-with Ada.Numerics.Float_Random; -- use Ada.Numerics.Float_Random;
+with Ada.Numerics.Float_Random;
 
+--  Cliff walking involves crossing a gridworld from start to goal while
+--  avoiding falling off a cliff.
+-- 
+--  ## Description
+--  The game starts with the player at location (3, 0) of the 4x12 grid world
+--  with the goal located at (3, 11). If the player reaches the goal the
+--  episode ends.
+-- 
+--  A cliff runs along (3, 1..10). If the player moves to a cliff location it
+--  returns to the start location.
+-- 
+--  The player makes moves until they reach the goal.
+-- 
+--  Adapted from Example 6.6 (page 132) from
+--  Reinforcement Learning: An Introduction
+--  by Sutton and Barto [<a href="#cliffwalk_ref">1</a>].
+-- 
+--  The cliff can be chosen to be slippery (disabled by default) so the player
+--  may move perpendicular to the intended direction sometimes.
+-- 
+--  With inspiration from:
+--  [https://github.com/dennybritz/reinforcement-learning/blob/master/lib/envs/cliff_walking.py](https://github.com/dennybritz/reinforcement-learning/blob/master/lib/envs/cliff_walking.py)
+-- 
+--  ## Action Space
+--  Actions represent moving in one of four directions, namely
+--  Left, Down, Right, or Up.
+-- 
+--  ## Observation Space
+--  There are 3 x 12 + 1 possible states. The player cannot be at the cliff, nor at
+--  the goal as the latter results in the end of the episode. What remains are all
+--  the positions of the first 3 rows plus the bottom-left cell.
+-- 
+--  The observation is a value representing the player's current position as
+--  current_row * ncols + current_col (where both the row and col start at 0).
+-- 
+--  For example, the starting position can be calculated as follows: 3 * 12 + 0 = 36.
+-- 
+--  The observation is returned as an `int()`.
+-- 
+--  ## Starting State
+--  The episode starts with the player in state `36` (location (3, 0)).
+-- 
+--  ## Reward
+--  Each time step incurs -1 reward, unless the player stepped into the cliff,
+--  which incurs -100 reward.
+-- 
+--  ## Episode End
+--  The episode terminates when the player enters state `47` (location (3, 11)).
+-- 
+--  ## Information
+-- 
+--  `step()` and `reset()` return a dict with the following keys:
+--  - "p" - transition proability for the state.
+-- 
+--  As cliff walking is not stochastic, the transition probability returned always 1.0.
+-- 
+--  ## References
+--  “Reinforcement Learning: An Introduction” 2020. [Online]. Available:
+--  [http://www.incompleteideas.net/book/RLbook2020.pdf](http://www.incompleteideas.net/book/RLbook2020.pdf)
+-- 
+--  Some differences with the Python Gymnasium implementation include:
+--  * the Python version returns probability info (e.g., {"prob": 1})
+--    in the reset and step methods, whereas this implementation
+--    omits this info
 package RL.Envs.Cliffwalking is
-   --  Cliff walking involves crossing a gridworld from start to goal while avoiding falling off a cliff.
-   -- 
-   --  ## Description
-   --  The game starts with the player at location [3, 0] of the 4x12 grid world with the
-   --  goal located at [3, 11]. If the player reaches the goal the episode ends.
-   -- 
-   --  A cliff runs along [3, 1..10]. If the player moves to a cliff location it
-   --  returns to the start location.
-   -- 
-   --  The player makes moves until they reach the goal.
-   -- 
-   --  Adapted from Example 6.6 (page 132) from Reinforcement Learning: An Introduction
-   --  by Sutton and Barto [<a href="#cliffwalk_ref">1</a>].
-   -- 
-   --  The cliff can be chosen to be slippery (disabled by default) so the player may move perpendicular
-   --  to the intended direction sometimes (see <a href="#is_slippy">`is_slippery`</a>).
-   -- 
-   --  With inspiration from:
-   --  [https://github.com/dennybritz/reinforcement-learning/blob/master/lib/envs/cliff_walking.py](https://github.com/dennybritz/reinforcement-learning/blob/master/lib/envs/cliff_walking.py)
-   -- 
-   --  ## Action Space
-   --  The action shape is `(1,)` in the range `{0, 3}` indicating
-   --  which direction to move the player.
-   -- 
-   --  - 0: Move up
-   --  - 1: Move right
-   --  - 2: Move down
-   --  - 3: Move left
-   -- 
-   --  ## Observation Space
-   --  There are 3 x 12 + 1 possible states. The player cannot be at the cliff, nor at
-   --  the goal as the latter results in the end of the episode. What remains are all
-   --  the positions of the first 3 rows plus the bottom-left cell.
-   -- 
-   --  The observation is a value representing the player's current position as
-   --  current_row * ncols + current_col (where both the row and col start at 0).
-   -- 
-   --  For example, the starting position can be calculated as follows: 3 * 12 + 0 = 36.
-   -- 
-   --  The observation is returned as an `int()`.
-   -- 
-   --  ## Starting State
-   --  The episode starts with the player in state `[36]` (location [3, 0]).
-   -- 
-   --  ## Reward
-   --  Each time step incurs -1 reward, unless the player stepped into the cliff,
-   --  which incurs -100 reward.
-   -- 
-   --  ## Episode End
-   --  The episode terminates when the player enters state `[47]` (location [3, 11]).
-   -- 
-   --  ## Information
-   -- 
-   --  `step()` and `reset()` return a dict with the following keys:
-   --  - "p" - transition proability for the state.
-   -- 
-   --  As cliff walking is not stochastic, the transition probability returned always 1.0.
-   -- 
-   --  ## Arguments
-   -- 
-   --  ```python
-   --  import gymnasium as gym
-   --  gym.make('CliffWalking-v1')
-   --  ```
-   -- 
-   --  ## References
-   --  <a id="cliffwalk_ref"></a>[1] R. Sutton and A. Barto, “Reinforcement Learning:
-   --  An Introduction” 2020. [Online]. Available: [http://www.incompleteideas.net/book/RLbook2020.pdf](http://www.incompleteideas.net/book/RLbook2020.pdf)
-   -- 
-   --  ## Version History
-   --  - v1: Add slippery version of cliffwalking
-   --  - v0: Initial version release
-
    package Float_Random renames Ada.Numerics.Float_Random;
 
-   type Cell_Type is (Start, Ground, Cliff, Goal);
    type Action_Type is (Left, Down, Right, Up);
 
    Num_Rows : constant Positive := 4;
    Num_Cols : constant Positive := 12;
-
-   -- -- TODO: The following is experimental, and might not be needed in the future.
-   -- type Map_Info_Type is record
-   --    Map_Name: Map_Type;
-   --    Rows: Positive;
-   --    Cols: Positive;
-   -- end record;
-   -- function Get_Map_Info(Map_Name: Map_Type) return Map_Info_Type;
-   -- -- End of experimental code.
 
    type Environment_Config is record
       Is_Slippery : Boolean;
@@ -100,20 +79,15 @@ package RL.Envs.Cliffwalking is
    type Environment_State is limited private;
 
    type Observation_Type is new Natural range 0 .. (Num_Rows * Num_Cols - 1);
-   -- type Observation_Type is record
-   --    Position_Index : Natural;
-   -- end record;
    
    type Step_Return_Type is record
       Observation: Observation_Type;
       Reward: Float;
       Terminated: Boolean;
-      Truncated: Boolean;
    end record;
    
    function Make(config: Environment_Config) return Environment_State;
-   -- -- TODO: Add argument for seed
-   function Reset(Env : in out Environment_State) return Observation_Type;
+   function Reset(Env : in out Environment_State; Seed_Reset : Seed_Reset_Type) return Observation_Type;
    function Step(Env : in out Environment_State; action: Action_Type) return Step_Return_Type;
    -- Render_Text loosely follows the Python implementation, except that we use
    -- an "A" to indicate the position of the agent rather than an "x".
@@ -128,7 +102,9 @@ package RL.Envs.Cliffwalking is
    -- function Get_Model(config: Environment_Config) return Discrete_Model_Type;
 
 private
-   type Map_Element is (S, P, C, G);  -- P for regular ground
+   -- Map elements: S is Start, C is Cliff, G is Goal, and
+   -- P s for regular ground
+   type Map_Element is (S, P, C, G);  
    type Map_Array is array (1 .. Num_Rows, 1 .. Num_Cols) of Map_Element;
 
    type Position_Type is record

--- a/experiments/ada/rl/src/rl-envs-cliffwalking.ads
+++ b/experiments/ada/rl/src/rl-envs-cliffwalking.ads
@@ -15,7 +15,7 @@ with Ada.Numerics.Float_Random;
 -- 
 --  Adapted from Example 6.6 (page 132) from
 --  Reinforcement Learning: An Introduction
---  by Sutton and Barto [<a href="#cliffwalk_ref">1</a>].
+--  by Sutton and Barto.
 -- 
 --  The cliff can be chosen to be slippery (disabled by default) so the player
 --  may move perpendicular to the intended direction sometimes.
@@ -28,16 +28,15 @@ with Ada.Numerics.Float_Random;
 --  Left, Down, Right, or Up.
 -- 
 --  ## Observation Space
---  There are 3 x 12 + 1 possible states. The player cannot be at the cliff, nor at
---  the goal as the latter results in the end of the episode. What remains are all
---  the positions of the first 3 rows plus the bottom-left cell.
+--  There are 3 x 12 + 1 possible states. The player cannot be at the cliff,
+--  nor at the goal as the latter results in the end of the episode. What
+--  remains are all the positions of the first 3 rows plus the bottom-left cell.
 -- 
 --  The observation is a value representing the player's current position as
 --  current_row * ncols + current_col (where both the row and col start at 0).
 -- 
---  For example, the starting position can be calculated as follows: 3 * 12 + 0 = 36.
--- 
---  The observation is returned as an `int()`.
+--  For example, the starting position can be calculated as follows:
+--  3 * 12 + 0 = 36.
 -- 
 --  ## Starting State
 --  The episode starts with the player in state `36` (location (3, 0)).
@@ -49,11 +48,6 @@ with Ada.Numerics.Float_Random;
 --  ## Episode End
 --  The episode terminates when the player enters state `47` (location (3, 11)).
 -- 
---  ## Information
--- 
---  `step()` and `reset()` return a dict with the following keys:
---  - "p" - transition proability for the state.
--- 
 --  As cliff walking is not stochastic, the transition probability returned always 1.0.
 -- 
 --  ## References
@@ -64,6 +58,14 @@ with Ada.Numerics.Float_Random;
 --  * the Python version returns probability info (e.g., {"prob": 1})
 --    in the reset and step methods, whereas this implementation
 --    omits this info
+--  * contrary to the description above, in this Ada implementation the
+--    position of the agent is represented using a 1-based index for the row
+--    and column, but the public observation type is the flattened 0-based
+--    position index (the description above is taken from the Python 
+--    implementation with a few adjustments, and we decided to keep the
+--    explanation that consistently uses the 0-based indices to avoid
+--    confusion, particularly since the use of 1-based indices is 
+--    only used in the private part of the specification)
 package RL.Envs.Cliffwalking is
    package Float_Random renames Ada.Numerics.Float_Random;
 

--- a/experiments/ada/rl/src/rl-envs-cliffwalking.ads
+++ b/experiments/ada/rl/src/rl-envs-cliffwalking.ads
@@ -74,11 +74,11 @@ package RL.Envs.Cliffwalking is
    Num_Rows : constant Positive := 4;
    Num_Cols : constant Positive := 12;
 
-   type Environment_Config is record
+   type Config_Type is record
       Is_Slippery : Boolean;
    end record;
 
-   type Environment_State is limited private;
+   type Environment_Type is limited private;
 
    type Observation_Type is new Natural range 0 .. (Num_Rows * Num_Cols - 1);
    
@@ -88,12 +88,12 @@ package RL.Envs.Cliffwalking is
       Terminated: Boolean;
    end record;
    
-   function Make(config: Environment_Config) return Environment_State;
-   function Reset(Env : in out Environment_State; Seed_Reset : Seed_Reset_Type) return Observation_Type;
-   function Step(Env : in out Environment_State; action: Action_Type) return Step_Return_Type;
+   function Make(config: Config_Type) return Environment_Type;
+   function Reset(Env : in out Environment_Type; Seed_Reset : Seed_Reset_Type) return Observation_Type;
+   function Step(Env : in out Environment_Type; action: Action_Type) return Step_Return_Type;
    -- Render_Text loosely follows the Python implementation, except that we use
    -- an "A" to indicate the position of the agent rather than an "x".
-   procedure Render_Text(Env : Environment_State);
+   procedure Render_Text(Env : Environment_Type);
 
    -- type Discrete_State_Type is new Natural range 0 .. 63; -- Allow for 8x8 map.
    -- type Transition_Probability_Type is record
@@ -101,7 +101,7 @@ package RL.Envs.Cliffwalking is
    --     Reward : Float;
    -- end record;
    -- type Discrete_Model_Type is array (Discrete_State_Type, Action_Type, Discrete_State_Type) of Transition_Probability_Type;
-   -- function Get_Model(config: Environment_Config) return Discrete_Model_Type;
+   -- function Get_Model(config: Config_Type) return Discrete_Model_Type;
 
 private
    -- Map elements: S is Start, C is Cliff, G is Goal, and
@@ -134,7 +134,7 @@ private
    type Action_Transition_Type is array (Action_Type, Action_Type) of Transition_Type;
    type Map_Transitions is array (1 .. Num_Rows, 1 .. Num_Cols) of Action_Transition_Type;
 
-   type Environment_State is record
+   type Environment_Type is record
       Map: Map_Array;
       P : Map_Transitions;
       Agent_Position: Position_Type;
@@ -146,9 +146,9 @@ private
    -- or the methods of the same name in the Frozen Lake environment with the necessary
    -- adjustments for the different rules of Cliff Walking.
    -- We make these private since they are not intended to be used directly.
-   function Position_Inc(Rows : Positive; Cols : Positive; Position: Position_Type; Action: Action_Type) return Position_Type;
+   function Position_Inc(Position: Position_Type; Action: Action_Type) return Position_Type;
    function Update_Probability_Matrix(Map : Map_Array; Position: Position_Type; Action : Action_Type) return Partial_Transition_Type;
-   function To_S(Map: Map_Array; Position: Position_Type) return Observation_Type;
+   function To_S(Position: Position_Type) return Observation_Type;
    function Get_Start_Position(Map: Map_Array) return Position_Type;
 end RL.Envs.Cliffwalking;
 

--- a/experiments/ada/rl/src/rl-envs-cliffwalking.ads
+++ b/experiments/ada/rl/src/rl-envs-cliffwalking.ads
@@ -95,13 +95,9 @@ package RL.Envs.Cliffwalking is
    -- an "A" to indicate the position of the agent rather than an "x".
    procedure Render_Text(Env : Environment_Type);
 
-   -- type Discrete_State_Type is new Natural range 0 .. 63; -- Allow for 8x8 map.
-   -- type Transition_Probability_Type is record
-   --     Probability : Float;
-   --     Reward : Float;
-   -- end record;
-   -- type Discrete_Model_Type is array (Discrete_State_Type, Action_Type, Discrete_State_Type) of Transition_Probability_Type;
-   -- function Get_Model(config: Config_Type) return Discrete_Model_Type;
+   type State_Type is new Natural range 0 .. (Num_Rows * Num_Cols - 1);
+   type DP_Model_Type is array (State_Type, Action_Type, State_Type) of Transition_Probability_Type;
+   function Get_Model(Config: Config_Type) return DP_Model_Type;
 
 private
    -- Map elements: S is Start, C is Cliff, G is Goal, and
@@ -129,18 +125,17 @@ private
        Terminated: Boolean;
    end record;
 
-   -- TODO: Given we have a fixed number of rows and columns, do we need Action_Transition_Type?
-   -- Can we just extend the indices of Map_Transitions?
-   type Action_Transition_Type is array (Action_Type, Action_Type) of Transition_Type;
-   type Map_Transitions is array (1 .. Num_Rows, 1 .. Num_Cols) of Action_Transition_Type;
+   -- In Frozenlake we had an intermediate Action_Transition_Type, but for
+   -- this environment we simple extend Map_Transitions to have indices for the
+   -- actions.
+   type Map_Transitions is array (1 .. Num_Rows, 1 .. Num_Cols, Action_Type, Action_Type) of Transition_Type;
 
-   type Environment_Type is record
+   type Environment_Type is limited record
+      Gen: Float_Random.Generator;
       Map: Map_Array;
       P : Map_Transitions;
       Agent_Position: Position_Type;
    end record;
-   
-   Gen: Float_Random.Generator;
 
    -- These functions follow similar methods in the Python implementation of CliffWalkingEnv,
    -- or the methods of the same name in the Frozen Lake environment with the necessary

--- a/experiments/ada/rl/tests/src/cliffwalking_tests.adb
+++ b/experiments/ada/rl/tests/src/cliffwalking_tests.adb
@@ -1,0 +1,78 @@
+with AUnit.Assertions; use AUnit.Assertions;
+with RL; use RL;
+with RL.Envs.Cliffwalking; use RL.Envs.Cliffwalking;
+with RL.Algorithms.Random_Actions;
+with Ada.Text_IO; use Ada.Text_IO;
+
+package body Cliffwalking_Tests is
+
+   overriding function Name (T : Cliffwalking_Test_Case) return Test_String is
+     (Format ("Cliffwalking Tests       "));
+
+   overriding procedure Register_Tests (T : in out Cliffwalking_Test_Case) is
+      use AUnit.Test_Cases.Registration;
+   begin
+      Register_Routine
+        (T, Test_Cliffwalking_Random_Actions'Access, "Test Cliffwalking environment terminates eventually with random actions");
+      Register_Routine
+        (T, Test_Cliffwalking_DP_Model'Access, "Test Cliffwalking DP model transition probabilities");
+   end Register_Tests;
+
+   procedure Test_Cliffwalking_Random_Actions (T : in out Test_Cases.Test_Case'Class) is
+      pragma Unreferenced (T);
+
+      Config: Config_Type := Config_Type'(Is_Slippery => False);
+
+      function Get_Observation (Step_Return : Step_Return_Type) return Observation_Type is (Step_Return.Observation);
+      function Get_Reward(Step_Return : Step_Return_Type) return Float is (Step_Return.Reward);
+      function Get_Terminated_Flag(Step_Return : Step_Return_Type) return Boolean is (Step_Return.Terminated);
+      -- Note in the following we set the seed for reproducibility of the test
+      package Cliffwalking_Random_Actions is new RL.Algorithms.Random_Actions(
+           Config_Type => Config_Type,
+           Environment_Type => Environment_Type,
+           Observation_Type => Observation_Type,
+           Action_Type => Action_Type,
+           Step_Return_Type => Step_Return_Type,
+           Make => Make,
+           Reset => Reset,
+           Step => Step,
+           Get_Observation => Get_Observation,
+           Get_Reward => Get_Reward,
+           Get_Terminated_Flag => Get_Terminated_Flag,
+           Seed_Reset => Seed_Reset_Type'(Kind => Set_Seed, Seed => 123)
+        );
+        Sim_Summary : Cliffwalking_Random_Actions.Simulation_Summary;
+       
+    begin
+        Sim_Summary := Cliffwalking_Random_Actions.Uniform_Random_Actions (Config, False);
+        Put_Line("Number of steps taken: " & Sim_Summary.Num_Steps'Image);
+        Assert (Sim_Summary.Num_Steps <= 3500, "Steps exceeded 3500");
+        Assert (Sim_Summary.Total_Reward <= -Float(Sim_Summary.Num_Steps), "Reward exceeds negative of number of steps");
+    end Test_Cliffwalking_Random_Actions;
+   
+    procedure Test_Cliffwalking_DP_Model (T : in out Test_Case'Class) is
+        Config: Config_Type := Config_Type'(Is_Slippery => False);
+        DP_Model : DP_Model_Type := Get_Model(Config);
+        
+        Total_Transition_Prob : Float;
+
+        function Is_Approx_Equal(X, Y : Float; Epsilon : Float := 1.0e-6) return Boolean is
+        begin
+            return abs(X - Y) <= Epsilon;
+        end Is_Approx_Equal;
+    begin 
+        for S in State_Type loop
+            for A in Action_Type loop
+                Total_Transition_Prob := 0.0;
+                for S1 in State_Type loop
+                    Total_Transition_Prob := Total_Transition_Prob + DP_Model(S, A, S1).Probability;
+                end loop;
+                Assert (
+                    Is_Approx_Equal(Total_Transition_Prob, 1.0),
+                    "Transition probabilities for State " & S'Image
+                    & " and Action " & A'Image & " do not sum to 1.0"
+                );
+            end loop;
+        end loop;
+    end Test_Cliffwalking_DP_Model;
+end Cliffwalking_Tests;

--- a/experiments/ada/rl/tests/src/cliffwalking_tests.ads
+++ b/experiments/ada/rl/tests/src/cliffwalking_tests.ads
@@ -1,0 +1,14 @@
+with AUnit;            use AUnit;
+with AUnit.Test_Cases; use AUnit.Test_Cases;
+
+package Cliffwalking_Tests is
+   type Cliffwalking_Test_Case is new Test_Case with null record;
+
+   overriding function Name (T : Cliffwalking_Test_Case) return Message_String;
+   overriding procedure Register_Tests (T : in out Cliffwalking_Test_Case);
+   procedure Test_Cliffwalking_Random_Actions (T : in out Test_Case'Class);
+   procedure Test_Cliffwalking_DP_Model (T : in out Test_Case'Class);
+
+end Cliffwalking_Tests;
+
+

--- a/experiments/ada/rl/tests/src/reinforcement_learning_test_suite.adb
+++ b/experiments/ada/rl/tests/src/reinforcement_learning_test_suite.adb
@@ -1,5 +1,6 @@
 with Placeholder_Tests;        use Placeholder_Tests;
 with Frozenlake_Tests;         use Frozenlake_Tests;
+with Cliffwalking_Tests;       use Cliffwalking_Tests;
 
 package body Reinforcement_Learning_Test_Suite is
 
@@ -9,11 +10,13 @@ package body Reinforcement_Learning_Test_Suite is
 
    Placeholder_Test        : aliased Placeholder_Test_Case;
    Frozenlake_Test         : aliased Frozenlake_Test_Case;
+   Cliffwalking_Test       : aliased Cliffwalking_Test_Case;
 
    function Suite return Access_Test_Suite is
    begin
       Add_Test (Result'Access, Placeholder_Test'Access);
       Add_Test (Result'Access, Frozenlake_Test'Access);
+      Add_Test (Result'Access, Cliffwalking_Test'Access);
       return Result'Access;
    end Suite;
 

--- a/experiments/ada/rl/third_party/mathpaqs-generic_random_functions.adb
+++ b/experiments/ada/rl/third_party/mathpaqs-generic_random_functions.adb
@@ -1,7 +1,7 @@
 with Ada.Numerics;                      use Ada.Numerics;
 with Ada.Numerics.Generic_Elementary_Functions;
 
-package body Generic_Random_Functions is
+package body Mathpaqs.Generic_Random_Functions is
 
   -- Ada 95 Quality and Style Guide, 7.2.7:
   -- Tests for
@@ -59,4 +59,4 @@ package body Generic_Random_Functions is
     return 1.0 - (threshold / x) ** alpha;
   end Pareto_CDF;
 
-end Generic_Random_Functions;
+end Mathpaqs.Generic_Random_Functions;

--- a/experiments/ada/rl/third_party/mathpaqs-generic_random_functions.ads
+++ b/experiments/ada/rl/third_party/mathpaqs-generic_random_functions.ads
@@ -50,7 +50,7 @@ generic
 
   type Real is digits <> ;
 
-package Generic_Random_Functions is
+package Mathpaqs.Generic_Random_Functions is
 
   ---------------------------------------------------------------------------------
   --   =======================================================================   --
@@ -109,4 +109,4 @@ package Generic_Random_Functions is
 
   function Pareto_CDF (x, threshold, alpha: Real) return Real;
 
-end Generic_Random_Functions;
+end Mathpaqs.Generic_Random_Functions;

--- a/experiments/ada/rl/third_party/mathpaqs.ads
+++ b/experiments/ada/rl/third_party/mathpaqs.ads
@@ -1,0 +1,7 @@
+package Mathpaqs is
+    -- We include third party code from the mathpaqs package
+    -- The code can be found at https://github.com/zertovitch/mathpaqs .
+    -- We will include the license from the original file in any
+    -- subpackages, though unused code in the files will be deleted.
+    -- See also the NOTICES.txt file of this repo.
+end Mathpaqs;


### PR DESCRIPTION
We rename types to be more consistent with type names in other environments.  The cliffwalking code was originally based on the frozenlake implementation, and so we make some simplifications that are reasonable for this environment.