### PR TITLE
RL Ada Cliffwalking updates and tests

### DIFF
--- a/experiments/ada/rl/reinforcement_learning.gpr
+++ b/experiments/ada/rl/reinforcement_learning.gpr
@@ -4,7 +4,7 @@ project Reinforcement_Learning is
    for Library_Name use "Reinforcement_Learning";
    for Library_Version use Project'Library_Name & ".so." & Reinforcement_Learning_Config.Crate_Version;
 
-   for Source_Dirs use ("src/", "config/");
+   for Source_Dirs use ("src/", "config/", "third_party/");
    for Object_Dir use "obj/" & Reinforcement_Learning_Config.Build_Profile;
    for Create_Missing_Dirs use "True";
    for Library_Dir use "lib";

--- a/experiments/ada/rl/src/rl-algorithms-random_actions.adb
+++ b/experiments/ada/rl/src/rl-algorithms-random_actions.adb
@@ -7,7 +7,7 @@ package body RL.Algorithms.Random_Actions is
    function Uniform_Random_Actions (Config : Config_Type; Verbose : Boolean) return Simulation_Summary is
       package Action_Random is new Ada.Numerics.Discrete_Random(Result_Subtype => Action_Type);
       Gen: Action_Random.Generator;
-      Seed_Reset : Seed_Reset_Type := Seed_Reset_Type'(Kind => Set_Default);
+      -- Seed_Reset : Seed_Reset_Type := Seed_Reset_Type'(Kind => Set_Default);
       Env : Environment_Type := Make(Config);
       Obs: Observation_Type;
       Action: Action_Type;
@@ -15,7 +15,12 @@ package body RL.Algorithms.Random_Actions is
       I: Integer;
       Total_Reward: Float := 0.0;
    begin
-      Action_Random.Reset(Gen);
+      -- For reproducibility we use the Seed_Reset generic parameter to reset the action generator.
+      case Seed_Reset.Kind is
+         when Set_Default => Action_Random.Reset(Gen);
+         when No_Set      => null;
+         when Set_Seed    => Action_Random.Reset(Gen, Seed_Reset.Seed);
+      end case;
 
       Obs:= Reset(Env, Seed_Reset);
       I := 0;

--- a/experiments/ada/rl/src/rl-algorithms-random_actions.ads
+++ b/experiments/ada/rl/src/rl-algorithms-random_actions.ads
@@ -12,6 +12,8 @@ generic
    with function Get_Observation (Step_Return : Step_Return_Type) return Observation_Type;
    with function Get_Reward(Step_Return : Step_Return_Type) return Float;
    with function Get_Terminated_Flag(Step_Return : Step_Return_Type) return Boolean;
+
+   Seed_Reset : Seed_Reset_Type := (Kind => Set_Default);
 package RL.Algorithms.Random_Actions is
 
    type Simulation_Summary is record

--- a/experiments/ada/rl/src/rl-envs-carrental.adb
+++ b/experiments/ada/rl/src/rl-envs-carrental.adb
@@ -1,7 +1,8 @@
+with Ada.Text_IO; use Ada.Text_IO;
 with Ada.Numerics.Generic_Elementary_Functions;
 
 
-package body Car_Rental is
+package body RL.Envs.Carrental is
    package Math is new Ada.Numerics.Generic_Elementary_Functions(Float);
 
    function Poisson_PMF(Lambda : Float; N : Natural) return Float is
@@ -492,5 +493,4 @@ package body Car_Rental is
       return Calculate_Transition_Probability2(Config, Cars_After_Action.Cars_Moved, Cars_Count1);
    end Get_Transition_Values2;
 
-end Car_Rental;
-
+end RL.Envs.Carrental;

--- a/experiments/ada/rl/src/rl-envs-carrental.ads
+++ b/experiments/ada/rl/src/rl-envs-carrental.ads
@@ -1,12 +1,11 @@
-with Ada.Text_IO; use Ada.Text_IO;
-with Ada.Numerics;
-with Ada.Numerics.Float_Random; -- use Ada.Numerics.Float_Random;
-with Generic_Random_Functions;
+-- with Ada.Numerics;
+with Ada.Numerics.Float_Random;
+with Mathpaqs.Generic_Random_Functions;
 with System.Pool_Local;
 
-package Car_Rental is
+package RL.Envs.Carrental is
    package Float_Random renames Ada.Numerics.Float_Random;
-   package GRF is new Generic_Random_Functions(Real => Float);
+   package GRF is new Mathpaqs.Generic_Random_Functions(Real => Float);
 
    Lot_Size : constant Positive := 20;
    Max_Move : constant Positive := 5;
@@ -130,5 +129,5 @@ private
    function Step_Cars(Cars_Count : Cars_Per_Lot_Type; Action : Action_Type) return Cars_After_Action_Type;
    function Calculate_Transition_Probability2 (Config : Environment_Config; Cars_Moved : Natural; Prev_Cars : Cars_Per_Lot_Type) return Transition_Array_Type;
 
-end Car_Rental;
+end RL.Envs.Carrental;
 

--- a/experiments/ada/rl/src/rl-envs-cliffwalking.adb
+++ b/experiments/ada/rl/src/rl-envs-cliffwalking.adb
@@ -112,9 +112,9 @@ package body RL.Envs.Cliffwalking is
                for A in Action_Type loop
                   for A_Act in Action_Type loop
                      if A = A_Act then
-                        P(I, J)(A, A_Act) := (Probability => 1.0, Position => (Row => I, Col => J), Reward => 0.0, Terminated => True);
+                        P(I, J, A, A_Act) := (Probability => 1.0, Position => (Row => I, Col => J), Reward => 0.0, Terminated => True);
                      else
-                        P(I, J)(A, A_Act) := (Probability => 0.0, Position => (Row => I, Col => J), Reward => 0.0, Terminated => True);
+                        P(I, J, A, A_Act) := (Probability => 0.0, Position => (Row => I, Col => J), Reward => 0.0, Terminated => True);
                      end if;
                   end loop;
                end loop;
@@ -135,7 +135,7 @@ package body RL.Envs.Cliffwalking is
                            Temp_Probability := 0.0;
                         end if;
                      end if;
-                     P(I, J)(A, A_Actual) := (
+                     P(I, J, A, A_Actual) := (
                         Probability => Temp_Probability,
                         Position => Temp_Partial_Transition.Position,
                         Reward => Temp_Partial_Transition.Reward,
@@ -165,7 +165,7 @@ package body RL.Envs.Cliffwalking is
          Temp_Cumulative_Probability : Float := 0.0;
       begin
          for A_Act in Action_Type loop
-            Cumulative_Probability(A_Act) := P(I, J)(Action, A_Act).Probability + Temp_Cumulative_Probability;
+            Cumulative_Probability(A_Act) := P(I, J, Action, A_Act).Probability + Temp_Cumulative_Probability;
             Temp_Cumulative_Probability := Cumulative_Probability(A_Act);
          end loop;
          return Cumulative_Probability;
@@ -177,11 +177,11 @@ package body RL.Envs.Cliffwalking is
       begin
          for A_Act in Action_Type loop
             if Rand <= Cumulative_Probability(A_Act) then
-               return P(Position.Row, Position.Col)(Action, A_Act);
+               return P(Position.Row, Position.Col, Action, A_Act);
             end if;
          end loop;
          -- The following should never be reached as the cumulative probabilities should sum to 1.0
-         return P(Position.Row, Position.Col)(Action, Action_Type'First);
+         return P(Position.Row, Position.Col, Action, Action_Type'First);
       end Get_Random_Transition;
 
       -- Sample to obtain the transition based on the current position and the action taken by the Agent

--- a/experiments/ada/rl/src/rl-envs-cliffwalking.adb
+++ b/experiments/ada/rl/src/rl-envs-cliffwalking.adb
@@ -148,7 +148,7 @@ package body RL.Envs.Cliffwalking is
       end loop;
       
       return (
-         Map => Map, P => P, Agent_Position => Start_Position
+         Map => Map, P => P, Agent_Position => Start_Position, Gen => <>
       );
    end Make;
    
@@ -171,9 +171,11 @@ package body RL.Envs.Cliffwalking is
          return Cumulative_Probability;
       end Get_Cumulative_Probability;
       
-      function Get_Random_Transition(P : Map_Transitions; Position : Position_Type; Action : Action_Type) return Transition_Type is
+      function Get_Random_Transition(Env: in out Environment_Type; Action : Action_Type) return Transition_Type is
+         P : Map_Transitions := Env.P;
+         Position : Position_Type := Env.Agent_Position;
          Cumulative_Probability : Cumulative_Probability_Type := Get_Cumulative_Probability(P, Position, Action);
-         Rand : Float := Float_Random.Random(Gen);
+         Rand : Float := Float_Random.Random(Env.Gen);
       begin
          for A_Act in Action_Type loop
             if Rand <= Cumulative_Probability(A_Act) then
@@ -185,7 +187,7 @@ package body RL.Envs.Cliffwalking is
       end Get_Random_Transition;
 
       -- Sample to obtain the transition based on the current position and the action taken by the Agent
-      Transition : Transition_Type := Get_Random_Transition(Env.P, Env.Agent_Position, Action);
+      Transition : Transition_Type := Get_Random_Transition(Env, Action);
    begin
       -- Update the Agent's position based on the transition
       Env.Agent_Position := Transition.Position;
@@ -200,9 +202,9 @@ package body RL.Envs.Cliffwalking is
       Result : Observation_Type;
    begin
       case Seed_Reset.Kind is
-         when Set_Default => Float_Random.Reset(Gen);
+         when Set_Default => Float_Random.Reset(Env.Gen);
          when No_Set      => null;
-         when Set_Seed    => Float_Random.Reset(Gen, Seed_Reset.Seed);
+         when Set_Seed    => Float_Random.Reset(Env.Gen, Seed_Reset.Seed);
       end case;
       Env.Agent_Position := Get_Start_Position(Env.Map);
       Result := To_S(Env.Agent_Position);
@@ -239,5 +241,60 @@ package body RL.Envs.Cliffwalking is
          New_Line;
       end loop;
    end Render_Text;
-   
+
+   -- We follow the approach used for Frozenlake
+   function Get_Model(Config: Config_Type) return DP_Model_Type is
+      Res : DP_Model_Type := (others => (others => (others => (Probability => 0.0, Reward => 0.0))));
+      Env : Environment_Type := Make(Config);
+      Prev_State : State_Type;
+      Next_State : State_Type;
+
+      type Expected_Reward_Type is record
+         Probability_Weighted_Reward : Float := 0.0;
+         Total_Probability : Float := 0.0;
+      end record;
+      type Expected_Rewards_Type is array (State_Type) of Expected_Reward_Type;
+
+      Temp_Expected_Rewards : Expected_Rewards_Type;
+
+      Temp_Probability : Float;
+      Temp_Reward : Float;
+   begin
+      for I in Env.P'Range(1) loop
+         for J in Env.P'Range(2) loop
+            Prev_State := State_Type(To_S(Position_Type'(Row => I, Col => J)));
+            for A in Action_Type loop
+               -- When the cliff is slippery, an action can lead to state transitions
+               -- with different probabilities.
+               -- This can be seen when in a corner cell of the map, in which case
+               -- an action that would take you off the board (if there was no slipping)
+               -- will result in arriving at the same cell 2/3 of the time.
+               -- To obtain the correct values, we calculate the conditional expectation for
+               -- the state transitions.
+               -- This should also generalize if we were to consider state transitions with
+               -- non-uniform probabilities.
+               Temp_Expected_Rewards := (others => (Probability_Weighted_Reward => 0.0, Total_Probability => 0.0));
+
+               for A_Act in Action_Type loop
+                  Next_State := State_Type(To_S(Env.P(I, J, A, A_Act).Position));
+                  Temp_Probability := Env.P(I, J, A, A_Act).Probability;
+                  Temp_Reward := Env.P(I, J, A, A_Act).Reward;
+                  Temp_Expected_Rewards(Next_State).Probability_Weighted_Reward := Temp_Expected_Rewards(Next_State).Probability_Weighted_Reward + Temp_Probability * Temp_Reward;
+                  Temp_Expected_Rewards(Next_State).Total_Probability := Temp_Expected_Rewards(Next_State).Total_Probability + Temp_Probability;
+               end loop;
+               -- Now that we've processed the possible transitions and their probabilities for a given action,
+               -- we calculate the discrete transition probabilities and conditional rewards
+               for Next_State in Temp_Expected_Rewards'Range loop
+                  if Temp_Expected_Rewards(Next_State).Total_Probability > 0.0 then
+                     Res(Prev_State, A, Next_State) := (
+                        Probability => Temp_Expected_Rewards(Next_State).Total_Probability,
+                        Reward => Temp_Expected_Rewards(Next_State).Probability_Weighted_Reward / Temp_Expected_Rewards(Next_State).Total_Probability
+                     );
+                  end if;
+               end loop;
+            end loop;
+         end loop;
+      end loop;
+      return Res;
+   end Get_Model;
 end RL.Envs.Cliffwalking;

--- a/experiments/ada/rl/src/rl-envs-cliffwalking.ads
+++ b/experiments/ada/rl/src/rl-envs-cliffwalking.ads
@@ -95,13 +95,9 @@ package RL.Envs.Cliffwalking is
    -- an "A" to indicate the position of the agent rather than an "x".
    procedure Render_Text(Env : Environment_Type);
 
-   -- type Discrete_State_Type is new Natural range 0 .. 63; -- Allow for 8x8 map.
-   -- type Transition_Probability_Type is record
-   --     Probability : Float;
-   --     Reward : Float;
-   -- end record;
-   -- type Discrete_Model_Type is array (Discrete_State_Type, Action_Type, Discrete_State_Type) of Transition_Probability_Type;
-   -- function Get_Model(config: Config_Type) return Discrete_Model_Type;
+   type State_Type is new Natural range 0 .. (Num_Rows * Num_Cols - 1);
+   type DP_Model_Type is array (State_Type, Action_Type, State_Type) of Transition_Probability_Type;
+   function Get_Model(Config: Config_Type) return DP_Model_Type;
 
 private
    -- Map elements: S is Start, C is Cliff, G is Goal, and
@@ -134,13 +130,12 @@ private
    -- actions.
    type Map_Transitions is array (1 .. Num_Rows, 1 .. Num_Cols, Action_Type, Action_Type) of Transition_Type;
 
-   type Environment_Type is record
+   type Environment_Type is limited record
+      Gen: Float_Random.Generator;
       Map: Map_Array;
       P : Map_Transitions;
       Agent_Position: Position_Type;
    end record;
-   
-   Gen: Float_Random.Generator;
 
    -- These functions follow similar methods in the Python implementation of CliffWalkingEnv,
    -- or the methods of the same name in the Frozen Lake environment with the necessary

--- a/experiments/ada/rl/src/rl-envs-cliffwalking.ads
+++ b/experiments/ada/rl/src/rl-envs-cliffwalking.ads
@@ -129,9 +129,9 @@ private
        Terminated: Boolean;
    end record;
 
-   -- TODO: Given we have a fixed number of rows and columns, do we need Action_Transition_Type?
-   -- Can we just extend the indices of Map_Transitions?
-   -- type Action_Transition_Type is array (Action_Type, Action_Type) of Transition_Type;
+   -- In Frozenlake we had an intermediate Action_Transition_Type, but for
+   -- this environment we simple extend Map_Transitions to have indices for the
+   -- actions.
    type Map_Transitions is array (1 .. Num_Rows, 1 .. Num_Cols, Action_Type, Action_Type) of Transition_Type;
 
    type Environment_Type is record

--- a/experiments/ada/rl/src/rl-envs-cliffwalking.ads
+++ b/experiments/ada/rl/src/rl-envs-cliffwalking.ads
@@ -131,8 +131,8 @@ private
 
    -- TODO: Given we have a fixed number of rows and columns, do we need Action_Transition_Type?
    -- Can we just extend the indices of Map_Transitions?
-   type Action_Transition_Type is array (Action_Type, Action_Type) of Transition_Type;
-   type Map_Transitions is array (1 .. Num_Rows, 1 .. Num_Cols) of Action_Transition_Type;
+   -- type Action_Transition_Type is array (Action_Type, Action_Type) of Transition_Type;
+   type Map_Transitions is array (1 .. Num_Rows, 1 .. Num_Cols, Action_Type, Action_Type) of Transition_Type;
 
    type Environment_Type is record
       Map: Map_Array;

--- a/experiments/ada/rl/tests/src/cliffwalking_tests.adb
+++ b/experiments/ada/rl/tests/src/cliffwalking_tests.adb
@@ -14,6 +14,8 @@ package body Cliffwalking_Tests is
    begin
       Register_Routine
         (T, Test_Cliffwalking_Random_Actions'Access, "Test Cliffwalking environment terminates eventually with random actions");
+      Register_Routine
+        (T, Test_Cliffwalking_DP_Model'Access, "Test Cliffwalking DP model transition probabilities");
    end Register_Tests;
 
    procedure Test_Cliffwalking_Random_Actions (T : in out Test_Cases.Test_Case'Class) is
@@ -48,4 +50,29 @@ package body Cliffwalking_Tests is
         Assert (Sim_Summary.Total_Reward <= -Float(Sim_Summary.Num_Steps), "Reward exceeds negative of number of steps");
     end Test_Cliffwalking_Random_Actions;
    
+    procedure Test_Cliffwalking_DP_Model (T : in out Test_Case'Class) is
+        Config: Config_Type := Config_Type'(Is_Slippery => False);
+        DP_Model : DP_Model_Type := Get_Model(Config);
+        
+        Total_Transition_Prob : Float;
+
+        function Is_Approx_Equal(X, Y : Float; Epsilon : Float := 1.0e-6) return Boolean is
+        begin
+            return abs(X - Y) <= Epsilon;
+        end Is_Approx_Equal;
+    begin 
+        for S in State_Type loop
+            for A in Action_Type loop
+                Total_Transition_Prob := 0.0;
+                for S1 in State_Type loop
+                    Total_Transition_Prob := Total_Transition_Prob + DP_Model(S, A, S1).Probability;
+                end loop;
+                Assert (
+                    Is_Approx_Equal(Total_Transition_Prob, 1.0),
+                    "Transition probabilities for State " & S'Image
+                    & " and Action " & A'Image & " do not sum to 1.0"
+                );
+            end loop;
+        end loop;
+    end Test_Cliffwalking_DP_Model;
 end Cliffwalking_Tests;

--- a/experiments/ada/rl/tests/src/cliffwalking_tests.adb
+++ b/experiments/ada/rl/tests/src/cliffwalking_tests.adb
@@ -1,0 +1,51 @@
+with AUnit.Assertions; use AUnit.Assertions;
+with RL; use RL;
+with RL.Envs.Cliffwalking; use RL.Envs.Cliffwalking;
+with RL.Algorithms.Random_Actions;
+with Ada.Text_IO; use Ada.Text_IO;
+
+package body Cliffwalking_Tests is
+
+   overriding function Name (T : Cliffwalking_Test_Case) return Test_String is
+     (Format ("Cliffwalking Tests       "));
+
+   overriding procedure Register_Tests (T : in out Cliffwalking_Test_Case) is
+      use AUnit.Test_Cases.Registration;
+   begin
+      Register_Routine
+        (T, Test_Cliffwalking_Random_Actions'Access, "Test Cliffwalking environment terminates eventually with random actions");
+   end Register_Tests;
+
+   procedure Test_Cliffwalking_Random_Actions (T : in out Test_Cases.Test_Case'Class) is
+      pragma Unreferenced (T);
+
+      Config: Config_Type := Config_Type'(Is_Slippery => False);
+
+      function Get_Observation (Step_Return : Step_Return_Type) return Observation_Type is (Step_Return.Observation);
+      function Get_Reward(Step_Return : Step_Return_Type) return Float is (Step_Return.Reward);
+      function Get_Terminated_Flag(Step_Return : Step_Return_Type) return Boolean is (Step_Return.Terminated);
+      -- Note in the following we set the seed for reproducibility of the test
+      package Cliffwalking_Random_Actions is new RL.Algorithms.Random_Actions(
+           Config_Type => Config_Type,
+           Environment_Type => Environment_Type,
+           Observation_Type => Observation_Type,
+           Action_Type => Action_Type,
+           Step_Return_Type => Step_Return_Type,
+           Make => Make,
+           Reset => Reset,
+           Step => Step,
+           Get_Observation => Get_Observation,
+           Get_Reward => Get_Reward,
+           Get_Terminated_Flag => Get_Terminated_Flag,
+           Seed_Reset => Seed_Reset_Type'(Kind => Set_Seed, Seed => 123)
+        );
+        Sim_Summary : Cliffwalking_Random_Actions.Simulation_Summary;
+       
+    begin
+        Sim_Summary := Cliffwalking_Random_Actions.Uniform_Random_Actions (Config, False);
+        Put_Line("Number of steps taken: " & Sim_Summary.Num_Steps'Image);
+        Assert (Sim_Summary.Num_Steps <= 3500, "Steps exceeded 3500");
+        Assert (Sim_Summary.Total_Reward <= -Float(Sim_Summary.Num_Steps), "Reward exceeds negative of number of steps");
+    end Test_Cliffwalking_Random_Actions;
+   
+end Cliffwalking_Tests;

--- a/experiments/ada/rl/tests/src/cliffwalking_tests.ads
+++ b/experiments/ada/rl/tests/src/cliffwalking_tests.ads
@@ -7,6 +7,7 @@ package Cliffwalking_Tests is
    overriding function Name (T : Cliffwalking_Test_Case) return Message_String;
    overriding procedure Register_Tests (T : in out Cliffwalking_Test_Case);
    procedure Test_Cliffwalking_Random_Actions (T : in out Test_Case'Class);
+   procedure Test_Cliffwalking_DP_Model (T : in out Test_Case'Class);
 
 end Cliffwalking_Tests;
 

--- a/experiments/ada/rl/tests/src/cliffwalking_tests.ads
+++ b/experiments/ada/rl/tests/src/cliffwalking_tests.ads
@@ -1,0 +1,13 @@
+with AUnit;            use AUnit;
+with AUnit.Test_Cases; use AUnit.Test_Cases;
+
+package Cliffwalking_Tests is
+   type Cliffwalking_Test_Case is new Test_Case with null record;
+
+   overriding function Name (T : Cliffwalking_Test_Case) return Message_String;
+   overriding procedure Register_Tests (T : in out Cliffwalking_Test_Case);
+   procedure Test_Cliffwalking_Random_Actions (T : in out Test_Case'Class);
+
+end Cliffwalking_Tests;
+
+

--- a/experiments/ada/rl/tests/src/reinforcement_learning_test_suite.adb
+++ b/experiments/ada/rl/tests/src/reinforcement_learning_test_suite.adb
@@ -1,5 +1,6 @@
 with Placeholder_Tests;        use Placeholder_Tests;
 with Frozenlake_Tests;         use Frozenlake_Tests;
+with Cliffwalking_Tests;       use Cliffwalking_Tests;
 
 package body Reinforcement_Learning_Test_Suite is
 
@@ -9,11 +10,13 @@ package body Reinforcement_Learning_Test_Suite is
 
    Placeholder_Test        : aliased Placeholder_Test_Case;
    Frozenlake_Test         : aliased Frozenlake_Test_Case;
+   Cliffwalking_Test       : aliased Cliffwalking_Test_Case;
 
    function Suite return Access_Test_Suite is
    begin
       Add_Test (Result'Access, Placeholder_Test'Access);
       Add_Test (Result'Access, Frozenlake_Test'Access);
+      Add_Test (Result'Access, Cliffwalking_Test'Access);
       return Result'Access;
    end Suite;
 

--- a/experiments/ada/rl/third_party/mathpaqs-generic_random_functions.adb
+++ b/experiments/ada/rl/third_party/mathpaqs-generic_random_functions.adb
@@ -1,7 +1,7 @@
 with Ada.Numerics;                      use Ada.Numerics;
 with Ada.Numerics.Generic_Elementary_Functions;
 
-package body Generic_Random_Functions is
+package body Mathpaqs.Generic_Random_Functions is
 
   -- Ada 95 Quality and Style Guide, 7.2.7:
   -- Tests for
@@ -59,4 +59,4 @@ package body Generic_Random_Functions is
     return 1.0 - (threshold / x) ** alpha;
   end Pareto_CDF;
 
-end Generic_Random_Functions;
+end Mathpaqs.Generic_Random_Functions;

--- a/experiments/ada/rl/third_party/mathpaqs-generic_random_functions.ads
+++ b/experiments/ada/rl/third_party/mathpaqs-generic_random_functions.ads
@@ -50,7 +50,7 @@ generic
 
   type Real is digits <> ;
 
-package Generic_Random_Functions is
+package Mathpaqs.Generic_Random_Functions is
 
   ---------------------------------------------------------------------------------
   --   =======================================================================   --
@@ -109,4 +109,4 @@ package Generic_Random_Functions is
 
   function Pareto_CDF (x, threshold, alpha: Real) return Real;
 
-end Generic_Random_Functions;
+end Mathpaqs.Generic_Random_Functions;

--- a/experiments/ada/rl/third_party/mathpaqs.ads
+++ b/experiments/ada/rl/third_party/mathpaqs.ads
@@ -1,0 +1,7 @@
+package Mathpaqs is
+    -- We include third party code from the mathpaqs package
+    -- The code can be found at https://github.com/zertovitch/mathpaqs .
+    -- We will include the license from the original file in any
+    -- subpackages, though unused code in the files will be deleted.
+    -- See also the NOTICES.txt file of this repo.
+end Mathpaqs;


### PR DESCRIPTION
We add a `Seed_Reset` value as a generic pararmeter for the random actions algorithm.  This algorithm is used in unit tests, and specifying the seed allows for reproducibility of results.

We add a unit test for the Cliffwalking environment.

Also we've made a small change to the type for tracking transition probabilities in the Cliffwalking environment.