### PR TITLE
RL Ada Car rental environment test cases and fix

### DIFF
--- a/experiments/ada/rl/src/rl-envs-carrental.adb
+++ b/experiments/ada/rl/src/rl-envs-carrental.adb
@@ -28,7 +28,7 @@ package body RL.Envs.Carrental is
          PMF := PMF * (Lambda / Float(I)); -- PMF(i) = PMF(i-1) * (lambda / i)
          CDF := CDF + PMF;
       end loop;
-      return CDF;
+      return Float'Min(CDF, 1.0);
    end Poisson_CDF;
    
    function Poisson_SF(Lambda : Float; N : Natural) return Float is
@@ -224,10 +224,19 @@ package body RL.Envs.Carrental is
          end loop;
       end loop;
 
-      return Transition_Probability_Type'(
-         Probability => Total_Probability,
-         Reward => (Probability_Weighted_Reward / Total_Probability) - 2.0 * Float(Cars_Moved)
-      );
+      if Total_Probability > 0.0 then
+         return Transition_Probability_Type'(
+            Probability => Total_Probability,
+            Reward => (Probability_Weighted_Reward / Total_Probability) - 2.0 * Float(Cars_Moved)
+         );
+      else
+         -- From testing it does not appear this case is reached,
+         -- but it is included for completeness.
+         return Transition_Probability_Type'(
+            Probability => 0.0,
+            Reward => 0.0
+         );
+      end if;
    end Calculate_Transition_Probability_Between_States;
 
    function Step_Cars(Cars_Count : Cars_Per_Lot_Type; Action : Action_Type) return Cars_After_Action_Type is
@@ -369,7 +378,7 @@ package body RL.Envs.Carrental is
       return Res;
    end Calculate_Transition_Probabilities_From_State;
    
-   function Get_Transition_Values (Config: Config_Type; State: Discrete_State_Type; Action: Action_Type) return Transition_Array_Type is
+   function Collect_Transition_Values (Config: Config_Type; State: Discrete_State_Type; Action: Action_Type) return Transition_Array_Type is
       Res : Transition_Array_Type := (others => (Probability => 0.0, Reward => 0.0));
       
       Cars_Count0 : Cars_Per_Lot_Type;
@@ -385,9 +394,9 @@ package body RL.Envs.Carrental is
          Res(S2) := Calculate_Transition_Probability_Between_States (Config, Cars_After_Action.Cars_Moved, Cars_Count1, Cars_Count2);
       end loop;
       return Res;
-   end Get_Transition_Values;
+   end Collect_Transition_Values;
 
-   function Get_Transition_Values2 (Config: Config_Type; State: Discrete_State_Type; Action: Action_Type) return Transition_Array_Type is
+   function Get_Transition_Values_From_State (Config: Config_Type; State: Discrete_State_Type; Action: Action_Type) return Transition_Array_Type is
       Cars_Count0 : Cars_Per_Lot_Type;
       Cars_After_Action : Cars_After_Action_Type;
       Cars_Count1 : Cars_Per_Lot_Type;
@@ -396,6 +405,6 @@ package body RL.Envs.Carrental is
       Cars_After_Action := Step_Cars(Cars_Count0, Action);
       Cars_Count1 := Cars_After_Action.Cars_Per_Lot;
       return Calculate_Transition_Probabilities_From_State (Config, Cars_After_Action.Cars_Moved, Cars_Count1);
-   end Get_Transition_Values2;
+   end Get_Transition_Values_From_State;
 
 end RL.Envs.Carrental;

--- a/experiments/ada/rl/src/rl-envs-carrental.ads
+++ b/experiments/ada/rl/src/rl-envs-carrental.ads
@@ -130,9 +130,8 @@ package RL.Envs.Carrental is
    function Get_Model(Config: Config_Type) return DP_Model_Access_Type;
 
    type Transition_Array_Type is array (Discrete_State_Type) of Transition_Probability_Type;
-   function Get_Transition_Values (Config: Config_Type; State: Discrete_State_Type; Action: Action_Type) return Transition_Array_Type;
-   function Get_Transition_Values2 (Config: Config_Type; State: Discrete_State_Type; Action: Action_Type) return Transition_Array_Type;
-
+   function Collect_Transition_Values (Config: Config_Type; State: Discrete_State_Type; Action: Action_Type) return Transition_Array_Type;
+   function Get_Transition_Values_From_State (Config: Config_Type; State: Discrete_State_Type; Action: Action_Type) return Transition_Array_Type;
 private
    type Environment_Type is record
       Gen: Float_Random.Generator;

--- a/experiments/ada/rl/tests/src/carrental_tests.adb
+++ b/experiments/ada/rl/tests/src/carrental_tests.adb
@@ -14,9 +14,12 @@ package body Carrental_Tests is
       Register_Routine
         (T, Test_Carrental_Random_Action'Access
         , "Test Carrental environment using a random action");
-      --  Register_Routine
-      --    (T, Test_Carrental_DP_Model'Access
-      --    , "Test Carrental DP model transition probabilities");
+      Register_Routine
+         (T, Test_Carrental_DP_Model'Access
+         , "Test Carrental DP model transition probabilities");
+      Register_Routine
+        (T, Test_Carrental_Transition_Values'Access
+        , "Test Carrental transition values using two different approaches");
    end Register_Tests;
 
    procedure Test_Carrental_Random_Action
@@ -51,31 +54,91 @@ package body Carrental_Tests is
                 , "Carrental environment should not terminate");
    end Test_Carrental_Random_Action;
 
-    --  procedure Test_Carrental_DP_Model (T : in out Test_Case'Class) is
-    --      Config: Config_Type := Config_Type'(Is_Slippery => False);
-    --      DP_Model : DP_Model_Type := Get_Model(Config);
-    --
-    --      Total_Transition_Prob : Float;
+   procedure Test_Carrental_DP_Model (T : in out Test_Case'Class) is
+      pragma Unreferenced (T);
+      Config : constant Config_Type := Default_Config;
+      DP_Model : constant DP_Model_Access_Type := Get_Model (Config);
 
-    --      function Is_Approx_Equal(X, Y : Float; Epsilon : Float := 1.0e-6)
-    --         return Boolean is
-    --      begin
-    --          return abs(X - Y) <= Epsilon;
-    --      end Is_Approx_Equal;
-    --  begin
-    --      for S in State_Type loop
-    --          for A in Action_Type loop
-    --              Total_Transition_Prob := 0.0;
-    --              for S1 in State_Type loop
-    --                  Total_Transition_Prob := Total_Transition_Prob
-   --                                         + DP_Model(S, A, S1).Probability;
-    --              end loop;
-    --              Assert (
-    --                  Is_Approx_Equal(Total_Transition_Prob, 1.0),
-    --                  "Transition probabilities for State " & S'Image
-    --                  & " and Action " & A'Image & " do not sum to 1.0"
-    --              );
-    --          end loop;
-    --      end loop;
-    --  end Test_Carrental_DP_Model;
+      Total_Transition_Prob : Float;
+
+      function Is_Approx_Equal (X, Y : Float; Epsilon : Float := 1.0e-6)
+         return Boolean is
+      begin
+         return abs (X - Y) <= Epsilon;
+      end Is_Approx_Equal;
+   begin
+      for S in Discrete_State_Type loop
+         for A in Action_Type loop
+            Total_Transition_Prob := 0.0;
+            for S1 in Discrete_State_Type loop
+               Total_Transition_Prob := Total_Transition_Prob
+                                        + DP_Model (S, A, S1).Probability;
+            end loop;
+            Assert (
+               Is_Approx_Equal (Total_Transition_Prob, 1.0),
+               "Transition probabilities for State " & S'Image
+               & " and Action " & A'Image & " do not sum to 1.0"
+            );
+         end loop;
+      end loop;
+   end Test_Carrental_DP_Model;
+
+   procedure Test_Carrental_Transition_Values
+      (T : in out Test_Cases.Test_Case'Class) is
+      pragma Unreferenced (T);
+      Config : constant Config_Type := Default_Config;
+
+      Collected_Transitions : Transition_Array_Type;
+      Transitions_From_State : Transition_Array_Type;
+
+      function Is_Approx_Equal (X, Y : Float; Epsilon : Float := 1.0e-6)
+         return Boolean is
+      begin
+         return abs (X - Y) <= Epsilon;
+      end Is_Approx_Equal;
+   begin
+      for S in Discrete_State_Type loop
+         for A in Action_Type loop
+            Collected_Transitions := Collect_Transition_Values (Config, S, A);
+            Transitions_From_State := Get_Transition_Values_From_State (
+               Config, S, A
+            );
+            for S2 in Collected_Transitions'Range loop
+               Assert (
+                  Is_Approx_Equal (
+                     Collected_Transitions (S2).Probability,
+                     Transitions_From_State (S2).Probability,
+                     Epsilon => 1.0e-7
+                  ),
+                  "Transition probabilities do not match for State "
+                       & S'Image & ", Action " & A'Image & ", Next State "
+                       & S2'Image
+                       & ". Collected: "
+                       & Float'Image (Collected_Transitions (S2).Probability)
+                       & ", From State: "
+                       & Float'Image (Transitions_From_State (S2).Probability)
+               );
+               --  Ideally We'd prefer the expected reward difference to be
+               --  orders of magnitude below 0.001, but given the
+               --  probability weights we do encounter differnces larger than
+               --  0.0001.
+               Assert (
+                  Is_Approx_Equal (
+                     Collected_Transitions (S2).Reward,
+                     Transitions_From_State (S2).Reward,
+                     Epsilon => 1.0e-3
+                  ),
+                  "Expected rewards do not match for State "
+                       & S'Image & ", Action " & A'Image & ", Next State "
+                       & S2'Image
+                       & ". Collected: "
+                       & Float'Image (Collected_Transitions (S2).Reward)
+                       & ", From State: "
+                       & Float'Image (Transitions_From_State (S2).Reward)
+              );
+            end loop;
+         end loop;
+      end loop;
+   end Test_Carrental_Transition_Values;
+
 end Carrental_Tests;

--- a/experiments/ada/rl/tests/src/carrental_tests.ads
+++ b/experiments/ada/rl/tests/src/carrental_tests.ads
@@ -7,6 +7,7 @@ package Carrental_Tests is
    overriding function Name (T : Carrental_Test_Case) return Message_String;
    overriding procedure Register_Tests (T : in out Carrental_Test_Case);
    procedure Test_Carrental_Random_Action (T : in out Test_Case'Class);
-   -- procedure Test_Carrental_DP_Model (T : in out Test_Case'Class);
+   procedure Test_Carrental_DP_Model (T : in out Test_Case'Class);
+   procedure Test_Carrental_Transition_Values (T : in out Test_Case'Class);
 
 end Carrental_Tests;


### PR DESCRIPTION
Adding test cases for the car rental environment.  Bounding the Poisson CDF at 1 to avoid negative transition probabilities.